### PR TITLE
Remove Sbpayment::Response#{ok|ng}_result?

### DIFF
--- a/lib/sbpayment/response.rb
+++ b/lib/sbpayment/response.rb
@@ -17,14 +17,6 @@ module Sbpayment
       @body    = decode @body, need_decrypt
     end
 
-    def ok_result?
-      body[:res_result] == 'OK'
-    end
-
-    def ng_result?
-      body[:res_result] == 'NG'
-    end
-
     def error
       code = body[:res_err_code]
       code && APIError.parse(code)

--- a/spec/requests/api/credit_spec.rb
+++ b/spec/requests/api/credit_spec.rb
@@ -56,7 +56,6 @@ describe 'Credit API behavior' do
       expect(res.status).to eq 200
       expect(res.headers['content-type']).to include 'text/xml'
       expect(res.body[:res_result]).to eq 'OK'
-      expect(res.ok_result?).to be_truthy
       expect(res.error).to be_nil
 
       # commit part
@@ -91,7 +90,6 @@ describe 'Credit API behavior' do
 
       res = req.perform
       expect(res.body[:res_result]).to eq 'NG'
-      expect(res.ok_result?).to be_falsey
     end
   end
 


### PR DESCRIPTION
The have other results. And clarify only `'OK'` and `'NG'` makes a bit confusion, I feel :bow: 