### PR TITLE
Rename class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ Action Name         | sps-api-request id | Request class                        
 
 ###### Docomo
 
-Action Name                                      | sps-api-request id | Request class                                            |
----                                              | ---                | ---                                                      |
-ドコモケータイ払い 取消・返金要求処理 (簡易継続) | `ST02-00303-401`   | `Sbpayment::API::Docomo::SimplifiedRefundRequest`        |
+Action Name                                      | sps-api-request id | Request class                                           |
+---                                              | ---                | ---                                                     |
+ドコモケータイ払い 取消・返金要求処理 (簡易継続) | `ST02-00303-401`   | `Sbpayment::API::Docomo::SimplifiedCancelRefundRequest` |
 
 ###### au
 
 Action Name                       | sps-api-request id | Request class                       |
 ---                               | ---                | ---                                 |
-auかんたん決済 取消・返金要求処理 | `ST02-00303-402`   | `Sbpayment::API::Au::RefundRequest` |
+auかんたん決済 取消・返金要求処理 | `ST02-00303-402`   | `Sbpayment::API::Au::CancelRefundRequest` |
 
 ###### Softbank
 

--- a/lib/sbpayment/api/au/cancel_refund.rb
+++ b/lib/sbpayment/api/au/cancel_refund.rb
@@ -3,15 +3,16 @@ require_relative '../../response'
 
 module Sbpayment
   module API
-    module Docomo
-      class SimplifiedRefundRequest < Request
+    module Au
+      class CancelRefundRequest < Request
         class PayOptionManage
           include ParameterDefinition
+
           tag 'pay_option_manage'
-          key :cancel_target_month
+          key :amount
         end
 
-        tag 'sps-api-request', id: 'ST02-00303-401'
+        tag 'sps-api-request', id: 'ST02-00303-402'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
         key :service_id,  default: -> { Sbpayment.config.default_service_id }
         key :tracking_id
@@ -21,8 +22,7 @@ module Sbpayment
         key :sps_hashcode
       end
 
-      class SimplifiedRefundResponse < Response
-        DECRYPT_PARAMETERS = %i(res_pay_method_info.res_cancel_type).freeze
+      class CancelRefundResponse < Response
       end
     end
   end

--- a/lib/sbpayment/api/au/cancel_refund.rb
+++ b/lib/sbpayment/api/au/cancel_refund.rb
@@ -23,6 +23,7 @@ module Sbpayment
       end
 
       class CancelRefundResponse < Response
+        DECRYPT_PARAMETERS = %i(res_pay_method_info.res_cancel_type).freeze
       end
     end
   end

--- a/lib/sbpayment/api/docomo/simplified_cancel_refund.rb
+++ b/lib/sbpayment/api/docomo/simplified_cancel_refund.rb
@@ -3,16 +3,15 @@ require_relative '../../response'
 
 module Sbpayment
   module API
-    module Au
-      class RefundRequest < Request
+    module Docomo
+      class SimplifiedCancelRefundRequest < Request
         class PayOptionManage
           include ParameterDefinition
-
           tag 'pay_option_manage'
-          key :amount
+          key :cancel_target_month
         end
 
-        tag 'sps-api-request', id: 'ST02-00303-402'
+        tag 'sps-api-request', id: 'ST02-00303-401'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
         key :service_id,  default: -> { Sbpayment.config.default_service_id }
         key :tracking_id
@@ -22,7 +21,8 @@ module Sbpayment
         key :sps_hashcode
       end
 
-      class RefundResponse < Response
+      class SimplifiedCancelRefundResponse < Response
+        DECRYPT_PARAMETERS = %i(res_pay_method_info.res_cancel_type).freeze
       end
     end
   end


### PR DESCRIPTION
* Rename class name. I misunderstood.
 * `Sbpayment::API::Docomo::SimplifiedRefundRequest` -> `Sbpayment::API::Docomo::SimplifiedCancelRefundRequest`
 * `Sbpayment::API::Au::RefundRequest` -> `Sbpayment::API::Au::CancelRefundRequest`
* Fix field definition: https://github.com/quipper/sbpayment.rb/commit/ff3cfb079dbab0cc68a607928dea353a0940f01c