### PR TITLE
Discard allow_multiple_service_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ hashkey                   | use hashkey given by sbpayment                      
 proxy_uri                 | set forward proxy uri if you need                                                                                                 | ""      | false    | String  |
 proxy_user                | set forward proxy's user if you need                                                                                              | ""      | false    | String  |
 proxy_password            | set forward proxy's password if you need                                                                                          | ""      | false    | String  |
-allow_multiple_service_id | if your application uses multiple service_id from 1 application, set true, then you need to pass service_id every time explicitly | false   | false    | Boolean |
 
 ### Supported Actions
 

--- a/lib/sbpayment/api/au/cancel_refund.rb
+++ b/lib/sbpayment/api/au/cancel_refund.rb
@@ -14,7 +14,7 @@ module Sbpayment
 
         tag 'sps-api-request', id: 'ST02-00303-402'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :tracking_id
         key :pay_option_manage, class: PayOptionManage
         key :request_date, default: -> { TimeUtil.format_current_time }

--- a/lib/sbpayment/api/credit/authorization.rb
+++ b/lib/sbpayment/api/credit/authorization.rb
@@ -36,7 +36,7 @@ module Sbpayment
 
         tag 'sps-api-request', id: 'ST01-00111-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :cust_code
         key :order_id
         key :item_id

--- a/lib/sbpayment/api/credit/cancel_authorization.rb
+++ b/lib/sbpayment/api/credit/cancel_authorization.rb
@@ -7,7 +7,7 @@ module Sbpayment
       class CancelAuthorizationRequest < Request
         tag 'sps-api-request', id: 'ST02-00305-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :sps_transaction_id
         key :tracking_id
         key :processing_datetime

--- a/lib/sbpayment/api/credit/commit.rb
+++ b/lib/sbpayment/api/credit/commit.rb
@@ -7,7 +7,7 @@ module Sbpayment
       class CommitRequest < Request
         tag 'sps-api-request', id: 'ST02-00101-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :sps_transaction_id
         key :tracking_id
         key :processing_datetime

--- a/lib/sbpayment/api/credit/create_customer.rb
+++ b/lib/sbpayment/api/credit/create_customer.rb
@@ -25,7 +25,7 @@ module Sbpayment
 
         tag 'sps-api-request', id: 'MG02-00101-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :cust_code
         key :sps_cust_info_return_flg, default: '1'
         key :pay_method_info, class: PayMethodInfo

--- a/lib/sbpayment/api/credit/delete_customer.rb
+++ b/lib/sbpayment/api/credit/delete_customer.rb
@@ -7,7 +7,7 @@ module Sbpayment
       class DeleteCustomerRequest < Request
         tag 'sps-api-request', id: 'MG02-00103-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :cust_code
         key :sps_cust_info_return_flg, default: '1'
         key :encrypted_flg, default: '1'

--- a/lib/sbpayment/api/credit/inquire_authorization.rb
+++ b/lib/sbpayment/api/credit/inquire_authorization.rb
@@ -14,7 +14,7 @@ module Sbpayment
 
         tag 'sps-api-request', id: 'MG01-00101-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :sps_transaction_id
         key :tracking_id
         key :response_info_type, default: '2'

--- a/lib/sbpayment/api/credit/partly_refund.rb
+++ b/lib/sbpayment/api/credit/partly_refund.rb
@@ -14,7 +14,7 @@ module Sbpayment
 
         tag 'sps-api-request', id: 'ST02-00307-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :sps_transaction_id
         key :tracking_id
         key :processing_datetime

--- a/lib/sbpayment/api/credit/re_authorization.rb
+++ b/lib/sbpayment/api/credit/re_authorization.rb
@@ -41,7 +41,7 @@ module Sbpayment
 
         tag 'sps-api-request', id: 'ST01-00113-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :tracking_id
         key :cust_code
         key :order_id

--- a/lib/sbpayment/api/credit/read_customer.rb
+++ b/lib/sbpayment/api/credit/read_customer.rb
@@ -14,7 +14,7 @@ module Sbpayment
 
         tag 'sps-api-request', id: 'MG02-00104-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :cust_code
         key :sps_cust_info_return_flg, default: '1'
         key :response_info_type, default: '2'

--- a/lib/sbpayment/api/credit/refund.rb
+++ b/lib/sbpayment/api/credit/refund.rb
@@ -7,7 +7,7 @@ module Sbpayment
       class RefundRequest < Request
         tag 'sps-api-request', id: 'ST02-00303-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :sps_transaction_id
         key :tracking_id
         key :processing_datetime

--- a/lib/sbpayment/api/credit/update_customer.rb
+++ b/lib/sbpayment/api/credit/update_customer.rb
@@ -25,7 +25,7 @@ module Sbpayment
 
         tag 'sps-api-request', id: 'MG02-00102-101'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :cust_code
         key :sps_cust_info_return_flg, default: '1'
         key :pay_method_info, class: PayMethodInfo

--- a/lib/sbpayment/api/docomo/simplified_cancel_refund.rb
+++ b/lib/sbpayment/api/docomo/simplified_cancel_refund.rb
@@ -13,7 +13,7 @@ module Sbpayment
 
         tag 'sps-api-request', id: 'ST02-00303-401'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :tracking_id
         key :pay_option_manage, class: PayOptionManage
         key :request_date, default: -> { TimeUtil.format_current_time }

--- a/lib/sbpayment/api/softbank/authorization.rb
+++ b/lib/sbpayment/api/softbank/authorization.rb
@@ -7,7 +7,7 @@ module Sbpayment
       class AuthorizationRequest < Request
         tag 'sps-api-request', id: 'ST01-00104-405'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :tracking_id
         key :cust_code
         key :order_id

--- a/lib/sbpayment/api/softbank/cancel_refund.rb
+++ b/lib/sbpayment/api/softbank/cancel_refund.rb
@@ -7,7 +7,7 @@ module Sbpayment
       class CancelRefundRequest < Request
         tag 'sps-api-request', id: 'ST02-00303-405'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
         key :sps_transaction_id
         key :tracking_id
         key :request_date, default: -> { TimeUtil.format_current_time }

--- a/lib/sbpayment/api/softbank/commit.rb
+++ b/lib/sbpayment/api/softbank/commit.rb
@@ -8,7 +8,6 @@ module Sbpayment
         tag 'sps-api-request', id: 'ST02-00201-405'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
         key :service_id,  default: -> { Sbpayment.config.service_id }
-        key :sps_transaction_id
         key :tracking_id
         key :request_date, default: -> { TimeUtil.format_current_time }
         key :limit_second

--- a/lib/sbpayment/api/softbank/commit.rb
+++ b/lib/sbpayment/api/softbank/commit.rb
@@ -7,7 +7,8 @@ module Sbpayment
       class CommitRequest < Request
         tag 'sps-api-request', id: 'ST02-00201-405'
         key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-        key :service_id,  default: -> { Sbpayment.config.default_service_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
+        key :sps_transaction_id
         key :tracking_id
         key :request_date, default: -> { TimeUtil.format_current_time }
         key :limit_second

--- a/lib/sbpayment/configuration.rb
+++ b/lib/sbpayment/configuration.rb
@@ -12,8 +12,6 @@ module Sbpayment
   end
   extend Configuration
 
-  class ConfigurationError < Sbpayment::Error; end
-
   class Config
     include Singleton
 

--- a/lib/sbpayment/configuration.rb
+++ b/lib/sbpayment/configuration.rb
@@ -29,26 +29,16 @@ module Sbpayment
       proxy_uri
       proxy_user
       proxy_password
-      allow_multiple_service_id
     ].freeze
 
     attr_accessor(*OPTION_KEYS)
 
     def initialize
       @sandbox = false
-      @allow_multiple_service_id = false
     end
 
     def []=(name, value)
       __send__ "#{name}=", value
-    end
-
-    def default_service_id
-      if !allow_multiple_service_id && service_id.nil?
-        raise ConfigurationError, 'needs to set service_id unless multiple service_id mode'
-      else
-        service_id
-      end
     end
   end
 end

--- a/lib/sbpayment/link/purchase_request.rb
+++ b/lib/sbpayment/link/purchase_request.rb
@@ -9,7 +9,7 @@ module Sbpayment
 
       key :pay_method
       key :merchant_id, default: -> { Sbpayment.config.merchant_id }
-      key :service_id,  default: -> { Sbpayment.config.default_service_id }
+      key :service_id,  default: -> { Sbpayment.config.service_id }
       key :cust_code
       key :sps_cust_no
       key :sps_payment_no

--- a/spec/sbpayment/configuration_spec.rb
+++ b/spec/sbpayment/configuration_spec.rb
@@ -7,49 +7,11 @@ describe Sbpayment::Configuration do
     end
   end
 
-  describe '#default_service_id' do
-    before do
-      Sbpayment.config.service_id = nil # For initialize
-    end
-
-    context 'when allow_multiple_service_id is false (default)' do
-      before do
-        Sbpayment.config.allow_multiple_service_id = false
-      end
-
-      context 'when service_id is not given' do
-        it 'raises a ConfigurationError' do
-          expect{ Sbpayment.config.default_service_id }.to raise_error(Sbpayment::ConfigurationError)
-        end
-      end
-
-      context 'when service_id is given' do
-        before do
-          Sbpayment.config.service_id = 'foo'
-        end
-
-        it 'returns service_id' do
-          expect(Sbpayment.config.default_service_id).to eq 'foo'
-        end
-      end
-    end
-
-    context 'when allow_multiple_service_id is true' do
-      before do
-        Sbpayment.config.allow_multiple_service_id = true
-      end
-
-      it 'returns nil' do
-        expect(Sbpayment.config.default_service_id).to be_nil
-      end
-    end
-  end
-
   describe 'configure' do
     let(:merchant_id) { SecureRandom.hex }
     let(:service_id)  { 'foo' }
 
-    before(:example) do
+    before do
       Sbpayment.configure do |x|
         x.merchant_id = merchant_id
         x['service_id'] = service_id


### PR DESCRIPTION
* As I said here https://github.com/quipper/sbpayment.rb/pull/29, if we set `allow_multiple_service_id = true`, it immediately raises an error, so [current implementation](https://github.com/quipper/sbpayment.rb/pull/15) is wrong and it's not intended.
*  Regarding spec, even if we have to treat multiple service id, `service_id` is not the only key we care. Other configuration also need to change. So my original idea was wrong: https://gist.github.com/banyan/391c754f8efbb49dbe09
* Tested and it does not break.