### PR TITLE
Add cancel_target_month to Sbpayment::API::Au::CancelRefundRequest

### DIFF
--- a/lib/sbpayment/api/au/cancel_refund.rb
+++ b/lib/sbpayment/api/au/cancel_refund.rb
@@ -7,9 +7,9 @@ module Sbpayment
       class CancelRefundRequest < Request
         class PayOptionManage
           include ParameterDefinition
-
           tag 'pay_option_manage'
           key :amount
+          key :cancel_target_month
         end
 
         tag 'sps-api-request', id: 'ST02-00303-402'


### PR DESCRIPTION
This is not covered in spec of SBPS as of 2016-03-04.
I had an error, then asked SBPS guy and turned out SBPS's spec was wrong :sweat_smile: 