### PR TITLE
Implement to controll retry counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ hashkey                   | use hashkey given by sbpayment                      
 proxy_uri                 | set forward proxy uri if you need                                                                                                 | ""      | false    | String  |
 proxy_user                | set forward proxy's user if you need                                                                                              | ""      | false    | String  |
 proxy_password            | set forward proxy's password if you need                                                                                          | ""      | false    | String  |
+retry_max_counts          | set max retry counts if you need                                                                                                  | 3       | false    | Integer |
+
 
 ### Supported Actions
 

--- a/lib/sbpayment/configuration.rb
+++ b/lib/sbpayment/configuration.rb
@@ -13,6 +13,8 @@ module Sbpayment
   extend Configuration
 
   class Config
+    RETRY_TIMES = 3
+
     include Singleton
 
     OPTION_KEYS = %i[
@@ -27,12 +29,14 @@ module Sbpayment
       proxy_uri
       proxy_user
       proxy_password
+      retry_max_counts
     ].freeze
 
     attr_accessor(*OPTION_KEYS)
 
     def initialize
       @sandbox = false
+      @retry_max_counts = RETRY_TIMES
     end
 
     def []=(name, value)

--- a/lib/sbpayment/request.rb
+++ b/lib/sbpayment/request.rb
@@ -3,7 +3,6 @@ require_relative 'parameter_definition'
 
 module Sbpayment
   class Request
-    RETRY_TIMES     = 3
     RETRY_INTERVAL  = 1
     DEFAULT_HEADERS = { 'content-type' => 'text/xml' }
 
@@ -19,7 +18,7 @@ module Sbpayment
       url = config.sandbox ? Sbpayment::SANDBOX_URL : Sbpayment::PRODUCTION_URL
 
       connection = Faraday.new(url: url) do |builder|
-        builder.request :retry, max: RETRY_TIMES, interval: RETRY_INTERVAL, exceptions: [Errno::ETIMEDOUT, Timeout::Error, Faraday::Error::TimeoutError]
+        builder.request :retry, max: config.retry_max_counts, interval: RETRY_INTERVAL, exceptions: [Errno::ETIMEDOUT, Timeout::Error, Faraday::Error::TimeoutError]
         builder.request :basic_auth, config.basic_auth_user, config.basic_auth_password
         builder.adapter Faraday.default_adapter
 

--- a/spec/sbpayment/configuration_spec.rb
+++ b/spec/sbpayment/configuration_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Sbpayment::Configuration do
+  before do
+    # reset Sbpayment::Config.instance for test because it's singleton
+    Sbpayment::Config.instance_variable_set('@singleton__instance__', nil)
+  end
+
   describe 'config' do
     it 'returns configuration store' do
       expect(Sbpayment.config).to be_instance_of Sbpayment::Config
@@ -21,6 +26,28 @@ describe Sbpayment::Configuration do
     it 'works' do
       expect(Sbpayment.config.merchant_id).to eq merchant_id
       expect(Sbpayment.config.service_id).to eq service_id
+    end
+  end
+
+  describe '#retry_max_counts' do
+    context 'when not changing retry_max_counts' do
+      it 'returns default value' do
+        expect(Sbpayment.config.retry_max_counts).to eq 3
+      end
+    end
+
+    context 'when changing retry_max_counts' do
+      let(:retry_max_counts)  { 0 }
+
+      before do
+        Sbpayment.configure do |x|
+          x.retry_max_counts = retry_max_counts
+        end
+      end
+
+      it 'returns setup value' do
+        expect(Sbpayment.config.retry_max_counts).to eq retry_max_counts
+      end
     end
   end
 end


### PR DESCRIPTION
I would like to control whether to retry or not. So I was going to add `enable_retry` option to configuration.
However it's also useful to controll retry counts, so I added `retry_max_counts` option.

Default behavior is same as before this pull request.

BTW thank you for creating this gem. 👍 