### PR TITLE
Support Faraday's timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ proxy_uri                 | set forward proxy uri if you need                   
 proxy_user                | set forward proxy's user if you need                                                                                              | ""      | false    | String  |
 proxy_password            | set forward proxy's password if you need                                                                                          | ""      | false    | String  |
 retry_max_counts          | set max retry counts if you need                                                                                                  | 3       | false    | Integer |
+open_timeout              | set number of seconds to wait for the connection to open                                                                          | nil     | false    | Integer |
+timeout                   | set number of seconds to wait for reading                                                                                         | nil     | false    | Integer |
 
 
 ### Supported Actions

--- a/lib/sbpayment/configuration.rb
+++ b/lib/sbpayment/configuration.rb
@@ -30,6 +30,8 @@ module Sbpayment
       proxy_user
       proxy_password
       retry_max_counts
+      open_timeout
+      timeout
     ].freeze
 
     attr_accessor(*OPTION_KEYS)

--- a/lib/sbpayment/request.rb
+++ b/lib/sbpayment/request.rb
@@ -17,7 +17,14 @@ module Sbpayment
 
       url = config.sandbox ? Sbpayment::SANDBOX_URL : Sbpayment::PRODUCTION_URL
 
-      connection = Faraday.new(url: url) do |builder|
+      faraday_options = {
+        url: url,
+        request: {
+          open_timeout: config.open_timeout,
+          timeout: config.timeout
+        }
+      }
+      connection = Faraday.new(faraday_options) do |builder|
         builder.request :retry, max: config.retry_max_counts, interval: RETRY_INTERVAL, exceptions: [Errno::ETIMEDOUT, Timeout::Error, Faraday::Error::TimeoutError]
         builder.request :basic_auth, config.basic_auth_user, config.basic_auth_password
         builder.adapter Faraday.default_adapter

--- a/spec/requests/api/timeout_spec.rb
+++ b/spec/requests/api/timeout_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'timeout behavior' do
+
+  def dummy_request
+    req = Sbpayment::API::Credit::AuthorizationRequest.new
+    req.encrypted_flg = '0'
+    req.cust_code = 'Quipper Customer ID'
+    req.order_id  = SecureRandom.hex
+    req.item_id   = 'Item ID'
+    req.amount    = 1000
+
+    req.pay_method_info.cc_number     = '4242424242424242'
+    req.pay_method_info.cc_expiration = '202001'
+    req.pay_method_info.security_code = '000'
+    req.pay_method_info.dealings_type = 10
+    req.pay_option_manage.cust_manage_flg = '1'
+    req
+  end
+
+  describe 'open_timeout and timeout settings' do
+    let(:faraday_options) {{
+      url: Sbpayment::SANDBOX_URL,
+      request: {
+        open_timeout: open_timeout,
+        timeout: timeout
+      }
+    }}
+
+    before do
+      Sbpayment.configure do |x|
+        x.sandbox = true
+        x.merchant_id = '30132'
+        x.service_id  = '002'
+        x.basic_auth_user     = '30132002'
+        x.basic_auth_password = '8435dbd48f2249807ec216c3d5ecab714264cc4a'
+        x.hashkey = '8435dbd48f2249807ec216c3d5ecab714264cc4a'
+        x.open_timeout = open_timeout
+        x.timeout = timeout
+      end
+    end
+
+    shared_examples 'to initialize Faraday with options' do
+      it 'passes timeout options' do
+        stub = stub_request(:post, Sbpayment::SANDBOX_URL + Sbpayment::API_PATH).to_timeout
+        expect(Faraday).to receive('new').with(faraday_options).and_call_original
+        req = dummy_request
+        expect { req.perform }.to raise_error(Faraday::Error::TimeoutError)
+        expect(stub).to have_been_requested.times(1)
+      end
+    end
+
+    context 'when timeout options as a number' do
+      let(:open_timeout) { 3 }
+      let(:timeout)      { 9 }
+
+      it_behaves_like 'to initialize Faraday with options'
+    end
+
+    context 'when timeout options as nil' do
+      let(:open_timeout) { nil }
+      let(:timeout)      { nil }
+
+      it_behaves_like 'to initialize Faraday with options'
+    end
+  end
+end

--- a/spec/sbpayment/configuration_spec.rb
+++ b/spec/sbpayment/configuration_spec.rb
@@ -50,4 +50,30 @@ describe Sbpayment::Configuration do
       end
     end
   end
+
+  describe 'timeout options' do
+    context 'when not changing timeout options' do
+      it 'returns default value' do
+        expect(Sbpayment.config.open_timeout).to be_nil
+        expect(Sbpayment.config.timeout).to be_nil
+      end
+    end
+
+    context 'when changing timeout options' do
+      let(:open_timeout) { 1 }
+      let(:timeout)      { 2 }
+
+      before do
+        Sbpayment.configure do |x|
+          x.open_timeout = open_timeout
+          x.timeout = timeout
+        end
+      end
+
+      it 'returns setup value' do
+        expect(Sbpayment.config.open_timeout).to eq open_timeout
+        expect(Sbpayment.config.timeout).to eq timeout
+      end
+    end
+  end
 end


### PR DESCRIPTION
I would like to control Faraday's timeout options, so this pull request supports both open_timeout and timeout options.

This pull request is based on #46's branch.
So I will rebase master branch after #46 was merged If this pull request was accepted.
