### PR TITLE
bugfix: credit sales key: pay_option_manage is not defined

### DIFF
--- a/lib/sbpayment/api/credit/sales.rb
+++ b/lib/sbpayment/api/credit/sales.rb
@@ -18,6 +18,7 @@ module Sbpayment
         key :sps_transaction_id
         key :tracking_id
         key :processing_datetime
+        key :pay_option_manage, class: PayOptionManage
         key :request_date, default: -> { TimeUtil.format_current_time }
         key :limit_second
         key :sps_hashcode


### PR DESCRIPTION
This branch fixes a bug in api/credit/sales.rb.
- API::Credit::SalesRequest has class: PayOptionManage, but the correspondent key definition is not defined in the class. 

The test for this fix is not implemented yet, please let me know if you have suggestion about it.