### PR TITLE
Clarify to load securerandom in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift(__dir__)
 $LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
 
+require 'securerandom'
 require 'sbpayment'
 require 'rspec'
 require 'webmock/rspec'


### PR DESCRIPTION
I didn't track the reason yet, but without this PR makes rspec/CI failure in current master 🤔 
