### PR TITLE
Remove unused global variable in test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,8 +9,6 @@ require 'vcr'
 require 'pry'
 require 'timecop'
 
-$test_env = true
-
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/vcr_cassettes'
   config.hook_into :webmock


### PR DESCRIPTION
I didn't know which code and/or dependency using this global variable...

📝 CI failure is another issue, it requires https://github.com/quipper/sbpayment.rb/pull/52
