### PR TITLE
Remove `free_csv` field from Sbpayment::Link::RoutineEntity

### DIFF
--- a/lib/sbpayment/link/routine_entry.rb
+++ b/lib/sbpayment/link/routine_entry.rb
@@ -23,7 +23,6 @@ module Sbpayment
       key :free1, type: :M
       key :free2, type: :M
       key :free3, type: :M
-      key :free_csv, type: :M
       key :request_date, default: -> { TimeUtil.format_current_time }
       key :limit_second
       key :sps_hashcode


### PR DESCRIPTION
One day we received the following email from SBPS and it compelled me to check the diff between `D01-n` specifications.

```
－－－－－－－－－－－－－－－－－－－－－－－－－－－－ 
【お知らせ】オンライン決済ASP仕様関連資料改定のご案内
－－－－－－－－－－－－－－－－－－－－－－－－－－－－ 
※当ご連絡はSBPSオンライン決済ASP利用のお客様向けご案内となります。


お客様各位 

拝啓　時下ますますご清栄のこととお慶び申し上げます。 
平素は弊社サービスをご利用いただき、誠にありがとうございます。 

オンライン決済ASPの仕様関連資料について改定を行いました。
以下の通りご連絡申し上げますので、ご確認ください。

　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　敬具

                                   記


■変更対象仕様書
　C004_リンク型システム仕様書（継続課金（定期・従量）申込要求）
　
■変更内容
　各仕様書の改定履歴をご確認ください。
　
■公開日
　2017年4月28日

■資料入手方法
　開発者支援サイト「Developer Console」仕様書ダウンロードページ
　https://developer.sbpayment.jp/document/show

■その他
　上記改定対象仕様書をご利用の場合は、必ず今回の修正版（20170428版）を再度ご確認ください。
```

After checking the latest document ([C004_リンク型システム仕様書（継続課金（定期・従量）申込要求）_20170428.pdf](https://github.com/quipper/sbpayment.rb/files/993167/C004_._20170428.pdf)), I found the `free_csv` field no longer exists, then we consequently have to remove it in order to follow the latest `D01-1` (`3.1. 要求項目定義`)  spec. (Its detail is in p.12.)

Although it reads `D02-1` (`3.2. 結果 CGI 項目定義`)  and `D03-1` (`3.4. 結果（画面返却）項目定義`) have changed, the current `sbpayment.rb` seems not to handle them.