### PR TITLE
Provide #retryable? in API errors when they have error type

### DIFF
--- a/lib/sbpayment/api_error/feature_modules.rb
+++ b/lib/sbpayment/api_error/feature_modules.rb
@@ -43,6 +43,10 @@ module Sbpayment
       def type
         self.class.type
       end
+
+      def retryable?
+        type.retryable?
+      end
     end
   end
 end

--- a/lib/sbpayment/api_error/fields.rb
+++ b/lib/sbpayment/api_error/fields.rb
@@ -63,7 +63,7 @@ module Sbpayment
       define_children_from TYPE_COMMON_DEFINITIONS
 
       def retryable?
-        !!/\A[89]/.match(code) # Can not use `match?` untill drop to less than ruby 2.4.0
+        !!/\A[89]/.match(code) # Can not use `match?` until drop to less than ruby 2.4.0
       end
     end
 

--- a/lib/sbpayment/api_error/fields.rb
+++ b/lib/sbpayment/api_error/fields.rb
@@ -61,6 +61,10 @@ module Sbpayment
       PATTERN = /\A[0-9a-zA-Z]{2}\z/
 
       define_children_from TYPE_COMMON_DEFINITIONS
+
+      def retryable?
+        !!/\A[89]/.match(code) # Can not use `match?` untill drop to less than ruby 2.4.0
+      end
     end
 
     class Item < Field

--- a/spec/sbpayment/errors_spec.rb
+++ b/spec/sbpayment/errors_spec.rb
@@ -36,6 +36,12 @@ describe Sbpayment::APIError do
         it 'knowns the type detail' do
           expect(subject.type.summary).to eq('桁数エラー')
         end
+
+        describe '#retryable?' do
+          it 'returns boolean as the type' do
+            expect(subject.retryable?).to eq(subject.type.retryable?)
+          end
+        end
       end
 
       context 'with known payment method' do
@@ -214,6 +220,28 @@ describe Sbpayment::APIError::Type do
 
     it 'raises an ArgumentError when given an invalid code' do
       expect { Sbpayment::APIError::Type.fetch '405' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#retryable?' do
+    subject { type.retryable? }
+
+    context 'on not a 8x/9x' do
+      let!(:type) { Sbpayment::APIError::Type.fetch('26') }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'on a 8x' do
+      let!(:type) { Sbpayment::APIError::Type.fetch('86') }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'on a 9x' do
+      let!(:type) { Sbpayment::APIError::Type.fetch('96') }
+
+      it { is_expected.to eq(true) }
     end
   end
 end


### PR DESCRIPTION
Some SBPS API errors can be retried and it can be determined via the error type. So these predicator will be useful, I think.