### PR TITLE
Implement Payeasy and Webcvs APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ Action Name                                              | sps-api-request id | 
 ソフトバンクまとめて支払い B 継続課金(定期) 確定処理     | `ST02-00201-405`   | `Sbpayment::API::Softbank::CommitRequest`        |
 ソフトバンクまとめて支払い(B)継続課金(定期) 取消返金要求 | `ST02-00303-405`   | `Sbpayment::API::Softbank::CancelRefundRequest`  |
 
+##### Webcvs
+
+Action Name               | sps-api-request id | Request class                                      |
+---                       | ---                | ---                                                |
+WEBコンビニ決済要求       | `ST01-00101-701`   | `Sbpayment::API::Webcvs::PaymentRequest`           |
+WEBコンビニ決済結果参照   | `ST01-00101-701`   | `Sbpayment::API::Webcvs::ReadPaymentResultRequest` |
+WEBコンビニ入金通知       | `NT01-00103-701`   | `Sbpayment::API::Webcvs::NoticeRequest`            |
+WEBコンビニキャンセル通知 | `NT01-00104-701`   | `Sbpayment::API::Webcvs::CancelRequest`            |
+
+##### Payeasy
+
+Action Name            | sps-api-request id | Request class                             |
+---                    | ---                | ---                                       |
+PayEasy 決済要求       | `ST01-00101-703`   | `Sbpayment::API::Payeasy::PaymentRequest` |
+PayEasy 入金通知       | `NT01-00103-703`   | `Sbpayment::API::Payeasy::NoticeRequest`  |
+PayEasy キャンセル通知 | `NT01-00104-703`   | `Sbpayment::API::Payeasy::CancelRequest`  |
+
 ## Tips
 
 ### Check error codes for debugging

--- a/lib/sbpayment.rb
+++ b/lib/sbpayment.rb
@@ -7,3 +7,5 @@ require 'sbpayment/link'
 
 Dir[File.join __dir__, 'sbpayment/api/**/*.rb'].each { |file| require file }
 Dir[File.join __dir__, 'sbpayment/link/**/*.rb'].each { |file| require file }
+
+require 'sbpayment/callback_factory'

--- a/lib/sbpayment/api/payeasy/cancel.rb
+++ b/lib/sbpayment/api/payeasy/cancel.rb
@@ -1,0 +1,17 @@
+require_relative '../../callback_request'
+require_relative '../../callback_response'
+
+module Sbpayment
+  module API
+    module Payeasy
+      class CancelRequest < CallbackRequest
+      end
+
+      class CancelResponse < CallbackResponse
+        tag 'sps-api-response', id: 'NT01-00104-703'
+        key :res_result
+        key :res_err_msg, type: :M
+      end
+    end
+  end
+end

--- a/lib/sbpayment/api/payeasy/notice.rb
+++ b/lib/sbpayment/api/payeasy/notice.rb
@@ -1,0 +1,22 @@
+require_relative '../../callback_request'
+require_relative '../../callback_response'
+
+module Sbpayment
+  module API
+    module Payeasy
+      class NoticeRequest < CallbackRequest
+        DECRYPT_PARAMETERS = %i(pay_method_info.rec_type
+                                pay_method_info.rec_amount
+                                pay_method_info.rec_amount_total
+                                pay_method_info.rec_mail
+                                pay_method_info.rec_extra).freeze
+      end
+
+      class NoticeResponse < CallbackResponse
+        tag 'sps-api-response', id: 'NT01-00103-703'
+        key :res_result
+        key :res_err_msg, type: :M
+      end
+    end
+  end
+end

--- a/lib/sbpayment/api/payeasy/payment.rb
+++ b/lib/sbpayment/api/payeasy/payment.rb
@@ -1,0 +1,77 @@
+require_relative '../../request'
+require_relative '../../response'
+
+module Sbpayment
+  module API
+    module Payeasy
+      class PaymentRequest < Request
+        class Detail
+          include ParameterDefinition
+
+          tag 'dtl'
+          key :dtl_rowno
+          key :dtl_item_id
+          key :dtl_item_name, type: :M
+          key :dtl_item_count
+          key :dtl_tax
+          key :dtl_amount
+        end
+        class PayMethodInfo
+          include ParameterDefinition
+
+          tag 'pay_method_info'
+          key :issue_type,                encrypt: true
+          key :last_name,       type: :M, encrypt: true
+          key :first_name,      type: :M, encrypt: true
+          key :last_name_kana,  type: :M, encrypt: true
+          key :first_name_kana, type: :M, encrypt: true
+          key :first_zip,                 encrypt: true
+          key :second_zip,                encrypt: true
+          key :add1,            type: :M, encrypt: true
+          key :add2,            type: :M, encrypt: true
+          key :add3,            type: :M, encrypt: true
+          key :tel,                       encrypt: true
+          key :mail,                      encrypt: true
+          key :seiyakudate,               encrypt: true
+          key :payeasy_type,              encrypt: true
+          key :terminal_value,            encrypt: true
+          key :pay_csv,                   encrypt: true
+          key :bill_info_kana,  type: :M, encrypt: true
+          key :bill_info,       type: :M, encrypt: true
+          key :bill_note,       type: :M, encrypt: true
+          key :bill_date,                 encrypt: true
+        end
+
+        tag 'sps-api-request', id: 'ST01-00101-703'
+        key :merchant_id, default: -> { Sbpayment.config.merchant_id }
+        key :service_id,  default: -> { Sbpayment.config.service_id }
+        key :cust_code
+        key :order_id
+        key :item_id
+        key :item_name, type: :M
+        key :tax
+        key :amount
+        key :free1, type: :M
+        key :free2, type: :M
+        key :free3, type: :M
+        key :order_rowno
+        many :dtls
+        key :pay_method_info, class: PayMethodInfo
+        key :encrypted_flg, default: '1'
+        key :request_date, default: -> { TimeUtil.format_current_time }
+        key :limit_second
+        key :sps_hashcode
+      end
+
+      class PaymentResponse < Response
+        DECRYPT_PARAMETERS = %i(res_pay_method_info.invoice_no
+                                res_pay_method_info.bill_date
+                                res_pay_method_info.skno
+                                res_pay_method_info.cust_number
+                                res_pay_method_info.bank_form
+                                res_pay_method_info.bptn
+                                res_pay_method_info.bill).freeze
+      end
+    end
+  end
+end

--- a/lib/sbpayment/api/webcvs/cancel.rb
+++ b/lib/sbpayment/api/webcvs/cancel.rb
@@ -1,0 +1,17 @@
+require_relative '../../callback_request'
+require_relative '../../callback_response'
+
+module Sbpayment
+  module API
+    module Webcvs
+      class CancelRequest < CallbackRequest
+      end
+
+      class CancelResponse < CallbackResponse
+        tag 'sps-api-response', id: 'NT01-00104-701'
+        key :res_result
+        key :res_err_msg, type: :M
+      end
+    end
+  end
+end

--- a/lib/sbpayment/api/webcvs/notice.rb
+++ b/lib/sbpayment/api/webcvs/notice.rb
@@ -1,0 +1,22 @@
+require_relative '../../callback_request'
+require_relative '../../callback_response'
+
+module Sbpayment
+  module API
+    module Webcvs
+      class NoticeRequest < CallbackRequest
+        DECRYPT_PARAMETERS = %i(pay_method_info.rec_type
+                                pay_method_info.rec_amount
+                                pay_method_info.rec_amount_total
+                                pay_method_info.rec_mail
+                                pay_method_info.rec_extra).freeze
+      end
+
+      class NoticeResponse < CallbackResponse
+        tag 'sps-api-response', id: 'NT01-00103-701'
+        key :res_result
+        key :res_err_msg, type: :M
+      end
+    end
+  end
+end

--- a/lib/sbpayment/callback_factory.rb
+++ b/lib/sbpayment/callback_factory.rb
@@ -1,0 +1,26 @@
+require 'xmlsimple'
+
+module Sbpayment
+  module CallbackFactory
+
+    module_function
+
+    def request(headers, body)
+      klass = detect_request(body)
+      klass.new headers, body
+    end
+
+    def detect_request(body)
+      request_class[XmlSimple.xml_in(body)['id']]
+    end
+
+    def request_class
+      {
+        'NT01-00103-701' => Sbpayment::API::Webcvs::NoticeRequest,
+        'NT01-00104-701' => Sbpayment::API::Webcvs::CancelRequest,
+        'NT01-00103-703' => Sbpayment::API::Payeasy::NoticeRequest,
+        'NT01-00104-703' => Sbpayment::API::Payeasy::CancelRequest
+      }
+    end
+  end
+end

--- a/lib/sbpayment/callback_request.rb
+++ b/lib/sbpayment/callback_request.rb
@@ -1,0 +1,25 @@
+require 'xmlsimple'
+require_relative 'shallow_hash'
+require_relative 'decode_parameters'
+require_relative 'parameter_definition'
+
+module Sbpayment
+  class CallbackRequest
+    using ShallowHash
+
+    include DecodeParameters
+    include ParameterDefinition
+
+    attr_reader :headers, :body
+
+    def initialize(headers, body, need_decrypt: false)
+      @headers = headers
+      @body    = XmlSimple.xml_in(body, forcearray: false, noattr: true, keytosymbol: true, suppressempty: true).shallow
+      @body    = decode @body, need_decrypt
+    end
+
+    def response_class
+      self.class.const_get self.class.name.sub(/Request\z/, 'Response')
+    end
+  end
+end

--- a/lib/sbpayment/callback_response.rb
+++ b/lib/sbpayment/callback_response.rb
@@ -1,0 +1,11 @@
+require_relative 'parameter_definition'
+
+module Sbpayment
+  class CallbackResponse
+    include ParameterDefinition
+
+    def to_xml
+      to_sbps_xml
+    end
+  end
+end

--- a/spec/fixtures/payeasy_cancel_request.xml
+++ b/spec/fixtures/payeasy_cancel_request.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='Shift_JIS' ?>
+<sps-api-request id="NT01-00104-703">
+  <merchant_id>99999</merchant_id>
+  <service_id>999</service_id>
+  <sps_transaction_id>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</sps_transaction_id>
+  <tracking_id>12345678901234</tracking_id>
+  <rec_datetime>20091010</rec_datetime>
+  <request_date>20091010125959</request_date>
+  <sps_hashcode>eead2e422cc837125950b2b53d9e42ed0ab598cc</sps_hashcode>
+</sps-api-request>

--- a/spec/fixtures/payeasy_cancel_response.xml
+++ b/spec/fixtures/payeasy_cancel_response.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="Shift_JIS"?><sps-api-response id="NT01-00104-703"><res_result>OK</res_result></sps-api-response>

--- a/spec/fixtures/payeasy_cancel_response_with_error.xml
+++ b/spec/fixtures/payeasy_cancel_response_with_error.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="Shift_JIS"?><sps-api-response id="NT01-00104-703"><res_result>NG</res_result><res_err_msg>g0eDiYFbg4GDYoNagVuDVw==</res_err_msg></sps-api-response>

--- a/spec/fixtures/payeasy_notice_request.xml
+++ b/spec/fixtures/payeasy_notice_request.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='Shift_JIS' ?>
+<sps-api-request id="NT01-00103-703">
+  <merchant_id>99999</merchant_id>
+  <service_id>999</service_id>
+  <sps_transaction_id>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</sps_transaction_id>
+  <tracking_id>12345678901234</tracking_id>
+  <rec_datetime>20091010</rec_datetime>
+  <pay_method_info>
+    <rec_type>1</rec_type>
+    <rec_amount>10800</rec_amount>
+    <rec_amount_total>10800</rec_amount_total>
+    <res_mail>payeasy@ps.softbank.co.jp</res_mail>
+    <rec_extra>備考</rec_extra>
+  </pay_method_info>
+  <request_date>20091010125959</request_date>
+  <sps_hashcode>eead2e422cc837125950b2b53d9e42ed0ab598cc</sps_hashcode>
+</sps-api-request>

--- a/spec/fixtures/payeasy_notice_response.xml
+++ b/spec/fixtures/payeasy_notice_response.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="Shift_JIS"?><sps-api-response id="NT01-00103-703"><res_result>OK</res_result></sps-api-response>

--- a/spec/fixtures/payeasy_notice_response_with_error.xml
+++ b/spec/fixtures/payeasy_notice_response_with_error.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="Shift_JIS"?><sps-api-response id="NT01-00103-703"><res_result>NG</res_result><res_err_msg>g0eDiYFbg4GDYoNagVuDVw==</res_err_msg></sps-api-response>

--- a/spec/fixtures/webcvs_cancel_request.xml
+++ b/spec/fixtures/webcvs_cancel_request.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='Shift_JIS' ?>
+<sps-api-request id="NT01-00104-701">
+  <merchant_id>99999</merchant_id>
+  <service_id>999</service_id>
+  <sps_transaction_id>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</sps_transaction_id>
+  <tracking_id>12345678901234</tracking_id>
+  <rec_datetime>20091010</rec_datetime>
+  <request_date>20091010125959</request_date>
+  <sps_hashcode>eead2e422cc837125950b2b53d9e42ed0ab598cc</sps_hashcode>
+</sps-api-request>

--- a/spec/fixtures/webcvs_cancel_response.xml
+++ b/spec/fixtures/webcvs_cancel_response.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="Shift_JIS"?><sps-api-response id="NT01-00104-701"><res_result>OK</res_result></sps-api-response>

--- a/spec/fixtures/webcvs_cancel_response_with_error.xml
+++ b/spec/fixtures/webcvs_cancel_response_with_error.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="Shift_JIS"?><sps-api-response id="NT01-00104-701"><res_result>NG</res_result><res_err_msg>g0eDiYFbg4GDYoNagVuDVw==</res_err_msg></sps-api-response>

--- a/spec/fixtures/webcvs_notice_request.xml
+++ b/spec/fixtures/webcvs_notice_request.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='Shift_JIS' ?>
+<sps-api-request id="NT01-00103-701">
+  <merchant_id>99999</merchant_id>
+  <service_id>999</service_id>
+  <sps_transaction_id>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</sps_transaction_id>
+  <tracking_id>12345678901234</tracking_id>
+  <rec_datetime>20091010</rec_datetime>
+  <pay_method_info>
+    <rec_type>1</rec_type>
+    <rec_amount>10800</rec_amount>
+    <rec_amount_total>10800</rec_amount_total>
+    <res_mail>payeasy@ps.softbank.co.jp</res_mail>
+    <rec_extra>備考</rec_extra>
+  </pay_method_info>
+  <request_date>20091010125959</request_date>
+  <sps_hashcode>eead2e422cc837125950b2b53d9e42ed0ab598cc</sps_hashcode>
+</sps-api-request>

--- a/spec/fixtures/webcvs_notice_response.xml
+++ b/spec/fixtures/webcvs_notice_response.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="Shift_JIS"?><sps-api-response id="NT01-00103-701"><res_result>OK</res_result></sps-api-response>

--- a/spec/fixtures/webcvs_notice_response_with_error.xml
+++ b/spec/fixtures/webcvs_notice_response_with_error.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="Shift_JIS"?><sps-api-response id="NT01-00103-701"><res_result>NG</res_result><res_err_msg>g0eDiYFbg4GDYoNagVuDVw==</res_err_msg></sps-api-response>

--- a/spec/requests/api/callback_spec.rb
+++ b/spec/requests/api/callback_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Sbpayment::CallbackFactory do
+  let(:request_header) { nil }
+
+  describe 'PayEasy Notice' do
+    let(:notice_body) { File.open("spec/fixtures/payeasy_notice_request.xml", "rb").read }
+
+    it 'works' do
+      expect(Sbpayment::CallbackFactory.request(nil, notice_body)).to be_instance_of Sbpayment::API::Payeasy::NoticeRequest
+    end
+  end
+
+  describe 'PayEasy Cancel' do
+    let(:cancel_body) { File.open("spec/fixtures/payeasy_cancel_request.xml", "rb").read }
+
+    it 'works' do
+      expect(Sbpayment::CallbackFactory.request(nil, cancel_body)).to be_instance_of Sbpayment::API::Payeasy::CancelRequest
+    end
+  end
+end

--- a/spec/vcr_cassettes/_webcvs-read-payment-result.yml
+++ b/spec/vcr_cassettes/_webcvs-read-payment-result.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://stbfep.sps-system.com/api/xmlapi.do
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="Shift_JIS"?><sps-api-request id="ST01-00101-701"><merchant_id>30132</merchant_id><service_id>002</service_id><cust_code>Quipper
+        Customer ID</cust_code><order_id>6d8a0d45b0b92a4adef4aae0f1cb2a3f</order_id><item_id>item_1</item_id><item_name>aXRlbQ==</item_name><amount>1250</amount><order_rowno>1</order_rowno><dtls><dtl><dtl_rowno>1</dtl_rowno><dtl_item_id>item_1</dtl_item_id><dtl_item_name>aXRlbSAx</dtl_item_name><dtl_item_count>2</dtl_item_count><dtl_amount>500</dtl_amount></dtl><dtl><dtl_rowno>2</dtl_rowno><dtl_item_id>item_2</dtl_item_id><dtl_item_name>aXRlbSAy</dtl_item_name><dtl_item_count>1</dtl_item_count><dtl_amount>250</dtl_amount></dtl></dtls><pay_method_info><issue_type>0</issue_type><last_name>gsSCt4LG</last_name><first_name>gUA=</first_name><last_name_kana>g2WDWINn</last_name_kana><first_zip>000</first_zip><second_zip>0000</second_zip><add1>gUA=</add1><add2>gUA=</add2><tel>0312345678</tel><mail>cvs@dummy.com</mail><seiyakudate>20161028</seiyakudate><webcvstype>001</webcvstype><bill_date>20161028</bill_date></pay_method_info><encrypted_flg>0</encrypted_flg><request_date>20161028190621</request_date><sps_hashcode>2963af3f6a4aeef2874a9f63959a99f81a378b6d</sps_hashcode></sps-api-request>
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - text/xml
+      Authorization:
+      - Basic MzAxMzIwMDI6ODQzNWRiZDQ4ZjIyNDk4MDdlYzIxNmMzZDVlY2FiNzE0MjY0Y2M0YQ==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Oct 2016 10:06:22 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=301A31AF3D140D151DCADDB4B1859D26.f115; Path=/api
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache,no-store,max-age=0
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Length:
+      - '221'
+      Connection:
+      - close
+      Content-Type:
+      - text/xml;charset=Shift_JIS
+      Content-Language:
+      - ja
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version='1.0' encoding='Shift_JIS' ?>
+          <sps-api-response id="ST01-00101-701">
+            <res_result>NG</res_result>
+            <res_err_code>70122999</res_err_code>
+            <res_date>20161028190622</res_date>
+          </sps-api-response>
+    http_version: 
+  recorded_at: Fri, 28 Oct 2016 10:06:22 GMT
+- request:
+    method: post
+    uri: https://stbfep.sps-system.com/api/xmlapi.do
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="Shift_JIS"?><sps-api-request id="MG01-00101-701"><merchant_id>30132</merchant_id><service_id>002</service_id><encrypted_flg>1</encrypted_flg><request_date>20161028190622</request_date><sps_hashcode>2417ee0892387195b7806c98bc55b05ea5421e6d</sps_hashcode></sps-api-request>
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - text/xml
+      Authorization:
+      - Basic MzAxMzIwMDI6ODQzNWRiZDQ4ZjIyNDk4MDdlYzIxNmMzZDVlY2FiNzE0MjY0Y2M0YQ==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Oct 2016 10:06:22 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=55F465B30ADF47BB6F1370E4F5C6E9DF.f115; Path=/api
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache,no-store,max-age=0
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Length:
+      - '201'
+      Connection:
+      - close
+      Content-Type:
+      - text/xml;charset=Shift_JIS
+      Content-Language:
+      - ja
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version='1.0' encoding='Shift_JIS' ?>
+          <sps-api-response>
+            <res_result>NG</res_result>
+            <res_err_code>70103026</res_err_code>
+            <res_date>20161028190623</res_date>
+          </sps-api-response>
+    http_version: 
+  recorded_at: Fri, 28 Oct 2016 10:06:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/payeasy-payment-request.yml
+++ b/spec/vcr_cassettes/payeasy-payment-request.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://stbfep.sps-system.com/api/xmlapi.do
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="Shift_JIS"?><sps-api-request id="ST01-00101-703"><merchant_id>30132</merchant_id><service_id>002</service_id><cust_code>Quipper
+        Customer ID</cust_code><order_id>4ab1f29554d64a742605ff01814e60a6</order_id><item_id>item1</item_id><item_name>aXRlbQ==</item_name><amount>1250</amount><order_rowno>1</order_rowno><dtls><dtl><dtl_rowno>1</dtl_rowno><dtl_item_id>item1</dtl_item_id><dtl_item_name>aXRlbTE=</dtl_item_name><dtl_item_count>2</dtl_item_count><dtl_amount>500</dtl_amount></dtl><dtl><dtl_rowno>2</dtl_rowno><dtl_item_id>item2</dtl_item_id><dtl_item_name>aXRlbTI=</dtl_item_name><dtl_item_count>1</dtl_item_count><dtl_amount>250</dtl_amount></dtl></dtls><pay_method_info><issue_type>0</issue_type><last_name>gsSCt4LG</last_name><first_name>gUA=</first_name><last_name_kana>g2WDWINn</last_name_kana><first_zip>000</first_zip><second_zip>0000</second_zip><add1>gUA=</add1><add2>gUA=</add2><tel>0312345678</tel><mail>cvs@dummy.com</mail><seiyakudate>20160829</seiyakudate><payeasy_type>O</payeasy_type><terminal_value>P</terminal_value><bill_info_kana>g1qDQ4NMg4WDRYNKg2k=</bill_info_kana><bill_info>kL+LgY/ulfE=</bill_info><bill_note>iseXnYOBg4I=</bill_note><bill_date>20160905</bill_date></pay_method_info><encrypted_flg>0</encrypted_flg><request_date>20160829180711</request_date><sps_hashcode>f45eabd249bb23d2e649cc07bc7b33ffcc601b88</sps_hashcode></sps-api-request>
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - text/xml
+      Authorization:
+      - Basic MzAxMzIwMDI6ODQzNWRiZDQ4ZjIyNDk4MDdlYzIxNmMzZDVlY2FiNzE0MjY0Y2M0YQ==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Aug 2016 09:07:11 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=BF26215F7192241D0A8F6EC5AA12FE25.f215; Path=/api
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache,no-store,max-age=0
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cteonnt-Length:
+      - '665'
+      Connection:
+      - close
+      Content-Type:
+      - text/xml;charset=Shift_JIS
+      Content-Language:
+      - ja
+      Content-Length:
+      - '334'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version='1.0' encoding='Shift_JIS' ?>
+          <sps-api-response id="ST01-00101-703">
+            <res_result>OK</res_result>
+            <res_sps_transaction_id>B30132002ST010010170300159847388</res_sps_transaction_id>
+            <res_tracking_id>83917088034266</res_tracking_id>
+            <res_pay_method_info>
+              <invoice_no>83917088034266</invoice_no>
+              <bill_date>20160905</bill_date>
+              <skno>59999</skno>
+              <cust_number>12345678901234567890-123456</cust_number>
+              <bank_form/>
+              <bptn/>
+              <bill/>
+            </res_pay_method_info>
+            <res_process_date>20160829180711</res_process_date>
+            <res_err_code/>
+            <res_date>20160829180711</res_date>
+          </sps-api-response>
+    http_version: 
+  recorded_at: Mon, 29 Aug 2016 09:07:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/webcvs-read-payment-result.yml
+++ b/spec/vcr_cassettes/webcvs-read-payment-result.yml
@@ -1,0 +1,130 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://stbfep.sps-system.com/api/xmlapi.do
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="Shift_JIS"?><sps-api-request id="ST01-00101-701"><merchant_id>71210</merchant_id><service_id>007</service_id><cust_code>Quipper
+        Customer ID</cust_code><order_id>fe0b5c11d445ebb4febe7f2db0ee0921</order_id><item_id>item_1</item_id><item_name>aXRlbQ==</item_name><amount>1250</amount><order_rowno>1</order_rowno><dtls><dtl><dtl_rowno>1</dtl_rowno><dtl_item_id>item_1</dtl_item_id><dtl_item_name>aXRlbSAx</dtl_item_name><dtl_item_count>2</dtl_item_count><dtl_amount>500</dtl_amount></dtl><dtl><dtl_rowno>2</dtl_rowno><dtl_item_id>item_2</dtl_item_id><dtl_item_name>aXRlbSAy</dtl_item_name><dtl_item_count>1</dtl_item_count><dtl_amount>250</dtl_amount></dtl></dtls><pay_method_info><issue_type>0</issue_type><last_name>gsSCt4LG</last_name><first_name>gUA=</first_name><last_name_kana>g2WDWINn</last_name_kana><first_zip>000</first_zip><second_zip>0000</second_zip><add1>gUA=</add1><add2>gUA=</add2><tel>0312345678</tel><mail>cvs@dummy.com</mail><seiyakudate>20161028</seiyakudate><webcvstype>002</webcvstype><bill_date>20161028</bill_date></pay_method_info><encrypted_flg>0</encrypted_flg><request_date>20161028192249</request_date><sps_hashcode>3994948d83bb6d66495b783f17d6e1aa93cb0864</sps_hashcode></sps-api-request>
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - text/xml
+      Authorization:
+      - Basic NzEyMTAwMDc6MTE3NWEzYzc2OTBjODdlZDE3NjY4NDJkYmViNDdmM2ZlNTdhOTdmNw==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Oct 2016 10:22:49 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=348171DDCF94B6CDFE25F3D3BF5E5580.f115; Path=/api
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache,no-store,max-age=0
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Length:
+      - '712'
+      Connection:
+      - close
+      Content-Type:
+      - text/xml;charset=Shift_JIS
+      Content-Language:
+      - ja
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version='1.0' encoding='Shift_JIS' ?>
+          <sps-api-response id="ST01-00101-701">
+            <res_result>OK</res_result>
+            <res_sps_transaction_id>B71210007ST010010170100188245648</res_sps_transaction_id>
+            <res_tracking_id>83897187434765</res_tracking_id>
+            <res_pay_method_info>
+              <invoice_no>83897187434765</invoice_no>
+              <bill_date>20161028</bill_date>
+              <cvs_pay_data1>30654892-426543614</cvs_pay_data1>
+              <cvs_pay_data2>https://cvsshiharai.densan-s.co.jp/Haraikomi.aspx?order1=30654892&amp;order2=426543614</cvs_pay_data2>
+            </res_pay_method_info>
+            <res_process_date>20161028192250</res_process_date>
+            <res_err_code/>
+            <res_date>20161028192250</res_date>
+          </sps-api-response>
+    http_version: 
+  recorded_at: Fri, 28 Oct 2016 10:22:50 GMT
+- request:
+    method: post
+    uri: https://stbfep.sps-system.com/api/xmlapi.do
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="Shift_JIS"?><sps-api-request id="MG01-00101-701"><merchant_id>71210</merchant_id><service_id>007</service_id><sps_transaction_id>B71210007ST010010170100188245648</sps_transaction_id><tracking_id>83897187434765</tracking_id><encrypted_flg>0</encrypted_flg><request_date>20161028192250</request_date><sps_hashcode>7a917d423de1fc1773286be7d09560743ec5f420</sps_hashcode></sps-api-request>
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - text/xml
+      Authorization:
+      - Basic NzEyMTAwMDc6MTE3NWEzYzc2OTBjODdlZDE3NjY4NDJkYmViNDdmM2ZlNTdhOTdmNw==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Oct 2016 10:22:50 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=F6F418F490FA7E1E4E7EB8E70699359B.f115; Path=/api
+      Pragma:
+      - No-cache
+      Cache-Control:
+      - no-cache,no-store,max-age=0
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Length:
+      - '765'
+      Connection:
+      - close
+      Content-Type:
+      - text/xml;charset=Shift_JIS
+      Content-Language:
+      - ja
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version='1.0' encoding='Shift_JIS' ?>
+          <sps-api-response id="MG01-00101-701">
+            <res_result>OK</res_result>
+            <res_sps_transaction_id>B71210007MG010010170100188245657</res_sps_transaction_id>
+            <res_status>0</res_status>
+            <res_pay_method_info>
+              <webcvstype>002</webcvstype>
+              <invoice_no>83897187434765</invoice_no>
+              <bill_date>20161028</bill_date>
+              <cvs_pay_data1>30654892-426543614</cvs_pay_data1>
+              <cvs_pay_data2>https://cvsshiharai.densan-s.co.jp/Haraikomi.aspx?order1=30654892&amp;order2=426543614</cvs_pay_data2>
+              <payment_status>1</payment_status>
+            </res_pay_method_info>
+            <res_process_date>20161028192250</res_process_date>
+            <res_err_code/>
+            <res_date>20161028192251</res_date>
+          </sps-api-response>
+    http_version: 
+  recorded_at: Fri, 28 Oct 2016 10:22:50 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Hajime Mashite. Let me PR a new component that handles Payeasy and Webcvs APIs.

The feature allows us to work with Payeasy/Webcvs requests, as well as incoming callbacks from SBPayment.

This PR is 99.9% based on the efforts made by @motchang (please refer to #45 for the previous PR) , which I happened to take over a last bit thanks to his kind offer.

It's been running stably on our web services for months, and we'd be happy if we could contribute to the original gem with these features :)