### PR TITLE
Add a filing spec

### DIFF
--- a/spec/sbpayment/errors_spec.rb
+++ b/spec/sbpayment/errors_spec.rb
@@ -83,6 +83,18 @@ describe Sbpayment::APIError do
         end
       end
     end
+
+    context 'with a known pattern "40203200"' do
+      subject { Sbpayment::APIError.parse '40203200' }
+
+      it 'returns a API40203Error' do
+        expect(subject).to be_an_instance_of(Sbpayment::API40203Error)
+      end
+
+      pending 'knows the item detail' do
+        expect(subject.item.summary).to eq('取消対象年月')
+      end
+    end
   end
 
   describe '#payment_method' do


### PR DESCRIPTION
This pattern should get item summary from https://github.com/quipper/sbpayment.rb/blob/60d2a4a9524fef58ada3c75fee897e3ffd531d53/lib/sbpayment/api_error/definitions.rb#L300-L302, but currently failed.
Sorry I didn't get the error cause yet 🙇 , this PR just adds the spec.