### PR TITLE
Add dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,6 @@
+# If you want to know dependabot config, see https://dependabot.com/docs/config-file/
+version: 1
+update_configs:
+  - directory: "/"
+    package_manager: "ruby:bundler"
+    update_schedule: "daily"


### PR DESCRIPTION
@quipper/aya-web-devs 
What do you think?

## Change

This pull request adds dependabot config file.

> You can configure multiple projects and languages from a file named config.yml. The config.yml file is located in a folder named .dependabot at the root of your repository.
> https://dependabot.com/docs/config-file/

## Benefit

We can change dependabot settings via pull requests, and we can track changes with git.
