### PR TITLE
Use proxy=() instead of removed proxy()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,34 @@
-references: &common
-  working_directory: ~/sbpayment.rb
-  steps:
-    - checkout
-    - run: gem update bundler
-    - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
-    - run: bundle exec rspec
+version: 2.1
 
-version: 2
 jobs:
-  build_ruby246:
-    <<: *common
+  test:
+    parameters:
+      gemfile:
+        type: string
+      ruby-image:
+        type: string
     docker:
-      - image: circleci/ruby:2.4.6-browsers
-  build_ruby255:
-    <<: *common
-    docker:
-      - image: circleci/ruby:2.5.5-browsers
-  build_ruby263:
-    <<: *common
-    docker:
-      - image: circleci/ruby:2.6.3-browsers
+      - image: << parameters.ruby-image >>
+    environment:
+      BUNDLE_GEMFILE: << parameters.gemfile >>
+    working_directory: ~/sbpayment.rb
+    steps:
+      - checkout
+      - run: gem update bundler
+      - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+      - run: bundle exec rspec
 
 workflows:
-  version: 2
-  build:
+  all-tests:
     jobs:
-      - build_ruby246
-      - build_ruby255
-      - build_ruby263
+      - test:
+          matrix:
+            parameters:
+              gemfile:
+                - gemfiles/faraday-0.16/Gemfile
+                - gemfiles/faraday-0.17/Gemfile
+                - gemfiles/faraday-1.0/Gemfile
+              ruby-image:
+                - circleci/ruby:2.4.6-browsers
+                - circleci/ruby:2.5.5-browsers
+                - circleci/ruby:2.6.3-browsers

--- a/gemfiles/faraday-0.16/Gemfile
+++ b/gemfiles/faraday-0.16/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in sbpayment.gemspec
+gemspec path: File.expand_path('../../..', __FILE__)
+
+gem 'faraday', '~> 0.16.0'
+
+gem 'pry-byebug'
+gem 'webdrivers' unless ENV.key?('CIRCLECI')

--- a/gemfiles/faraday-0.16/Gemfile
+++ b/gemfiles/faraday-0.16/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in sbpayment.gemspec
 gemspec path: File.expand_path('../../..', __FILE__)
 
-gem 'faraday', '~> 0.16.0'
+gem 'faraday', '0.16.2'
 
 gem 'pry-byebug'
 gem 'webdrivers' unless ENV.key?('CIRCLECI')

--- a/gemfiles/faraday-0.16/Gemfile.lock
+++ b/gemfiles/faraday-0.16/Gemfile.lock
@@ -1,0 +1,85 @@
+PATH
+  remote: /Users/a2ikm/src/github.com/quipper/sbpayment.rb
+  specs:
+    sbpayment (0.11.0)
+      builder
+      faraday (>= 0.16.0, < 1.1.0)
+      xml-simple
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    builder (3.2.4)
+    byebug (11.1.3)
+    childprocess (3.0.0)
+    coderay (1.1.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.4.4)
+    faraday (0.16.2)
+      multipart-post (>= 1.2, < 3)
+    hashdiff (1.0.1)
+    method_source (1.0.0)
+    mini_portile2 (2.4.0)
+    multipart-post (2.1.1)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    public_suffix (4.0.5)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubyzip (2.3.0)
+    safe_yaml (1.0.5)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    timecop (0.9.1)
+    vcr (5.1.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    xml-simple (1.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.1)
+  faraday (~> 0.16.0)
+  pry
+  pry-byebug
+  rake (~> 13.0)
+  rspec
+  sbpayment!
+  selenium-webdriver
+  timecop
+  vcr (~> 5.1.0)
+  webdrivers
+  webmock (~> 3.8.3)
+
+BUNDLED WITH
+   2.1.4

--- a/gemfiles/faraday-0.16/Gemfile.lock
+++ b/gemfiles/faraday-0.16/Gemfile.lock
@@ -69,7 +69,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.1)
-  faraday (~> 0.16.0)
+  faraday (= 0.16.2)
   pry
   pry-byebug
   rake (~> 13.0)

--- a/gemfiles/faraday-0.17/Gemfile
+++ b/gemfiles/faraday-0.17/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in sbpayment.gemspec
 gemspec path: File.expand_path('../../..', __FILE__)
 
-gem 'faraday', '~> 0.17.0'
+gem 'faraday', '0.17.3'
 
 gem 'pry-byebug'
 gem 'webdrivers' unless ENV.key?('CIRCLECI')

--- a/gemfiles/faraday-0.17/Gemfile
+++ b/gemfiles/faraday-0.17/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in sbpayment.gemspec
+gemspec path: File.expand_path('../../..', __FILE__)
+
+gem 'faraday', '~> 0.17.0'
+
+gem 'pry-byebug'
+gem 'webdrivers' unless ENV.key?('CIRCLECI')

--- a/gemfiles/faraday-0.17/Gemfile.lock
+++ b/gemfiles/faraday-0.17/Gemfile.lock
@@ -1,0 +1,85 @@
+PATH
+  remote: /Users/a2ikm/src/github.com/quipper/sbpayment.rb
+  specs:
+    sbpayment (0.11.0)
+      builder
+      faraday (>= 0.16.0, < 1.1.0)
+      xml-simple
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    builder (3.2.4)
+    byebug (11.1.3)
+    childprocess (3.0.0)
+    coderay (1.1.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.4.4)
+    faraday (0.17.3)
+      multipart-post (>= 1.2, < 3)
+    hashdiff (1.0.1)
+    method_source (1.0.0)
+    mini_portile2 (2.4.0)
+    multipart-post (2.1.1)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    public_suffix (4.0.5)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubyzip (2.3.0)
+    safe_yaml (1.0.5)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    timecop (0.9.1)
+    vcr (5.1.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    xml-simple (1.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.1)
+  faraday (~> 0.17.0)
+  pry
+  pry-byebug
+  rake (~> 13.0)
+  rspec
+  sbpayment!
+  selenium-webdriver
+  timecop
+  vcr (~> 5.1.0)
+  webdrivers
+  webmock (~> 3.8.3)
+
+BUNDLED WITH
+   2.1.4

--- a/gemfiles/faraday-0.17/Gemfile.lock
+++ b/gemfiles/faraday-0.17/Gemfile.lock
@@ -69,7 +69,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.1)
-  faraday (~> 0.17.0)
+  faraday (= 0.17.3)
   pry
   pry-byebug
   rake (~> 13.0)

--- a/gemfiles/faraday-1.0/Gemfile
+++ b/gemfiles/faraday-1.0/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in sbpayment.gemspec
+gemspec path: File.expand_path('../../..', __FILE__)
+
+gem 'faraday', '~> 1.0.0'
+
+gem 'pry-byebug'
+gem 'webdrivers' unless ENV.key?('CIRCLECI')

--- a/gemfiles/faraday-1.0/Gemfile
+++ b/gemfiles/faraday-1.0/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in sbpayment.gemspec
 gemspec path: File.expand_path('../../..', __FILE__)
 
-gem 'faraday', '~> 1.0.0'
+gem 'faraday', '1.0.1'
 
 gem 'pry-byebug'
 gem 'webdrivers' unless ENV.key?('CIRCLECI')

--- a/gemfiles/faraday-1.0/Gemfile.lock
+++ b/gemfiles/faraday-1.0/Gemfile.lock
@@ -69,7 +69,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.1)
-  faraday (~> 1.0.0)
+  faraday (= 1.0.1)
   pry
   pry-byebug
   rake (~> 13.0)

--- a/gemfiles/faraday-1.0/Gemfile.lock
+++ b/gemfiles/faraday-1.0/Gemfile.lock
@@ -1,0 +1,85 @@
+PATH
+  remote: /Users/a2ikm/src/github.com/quipper/sbpayment.rb
+  specs:
+    sbpayment (0.11.0)
+      builder
+      faraday (>= 0.16.0, < 1.1.0)
+      xml-simple
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    builder (3.2.4)
+    byebug (11.1.3)
+    childprocess (3.0.0)
+    coderay (1.1.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.4.4)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    hashdiff (1.0.1)
+    method_source (1.0.0)
+    mini_portile2 (2.4.0)
+    multipart-post (2.1.1)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    public_suffix (4.0.5)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubyzip (2.3.0)
+    safe_yaml (1.0.5)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    timecop (0.9.1)
+    vcr (5.1.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    xml-simple (1.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.1)
+  faraday (~> 1.0.0)
+  pry
+  pry-byebug
+  rake (~> 13.0)
+  rspec
+  sbpayment!
+  selenium-webdriver
+  timecop
+  vcr (~> 5.1.0)
+  webdrivers
+  webmock (~> 3.8.3)
+
+BUNDLED WITH
+   2.1.4

--- a/lib/sbpayment/request.rb
+++ b/lib/sbpayment/request.rb
@@ -31,7 +31,7 @@ module Sbpayment
 
         if config.proxy_uri
           options = { uri: config.proxy_uri, user: config.proxy_user, password: config.proxy_password }
-          builder.proxy options
+          builder.proxy = options
         end
       end
 

--- a/spec/requests/api/proxy_spec.rb
+++ b/spec/requests/api/proxy_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe 'proxy behavior' do
+
+  def dummy_request
+    req = Sbpayment::API::Credit::AuthorizationRequest.new
+    req.encrypted_flg = '0'
+    req.cust_code = 'Quipper Customer ID'
+    req.order_id  = SecureRandom.hex
+    req.item_id   = 'Item ID'
+    req.amount    = 1000
+
+    req.pay_method_info.cc_number     = '4242424242424242'
+    req.pay_method_info.cc_expiration = '202001'
+    req.pay_method_info.security_code = '000'
+    req.pay_method_info.dealings_type = 10
+    req.pay_option_manage.cust_manage_flg = '1'
+    req
+  end
+
+  describe 'proxy_uri settings' do
+    before do
+      Sbpayment.configure do |x|
+        x.sandbox = true
+        x.merchant_id = '30132'
+        x.service_id  = '002'
+        x.basic_auth_user     = '30132002'
+        x.basic_auth_password = '8435dbd48f2249807ec216c3d5ecab714264cc4a'
+        x.hashkey = '8435dbd48f2249807ec216c3d5ecab714264cc4a'
+        x.proxy_uri = proxy_uri
+        x.proxy_user = proxy_user
+        x.proxy_password = proxy_password
+      end
+    end
+
+    context 'when proxy options given' do
+      let(:proxy_uri) { 'http://proxy.example.com:8000' }
+      let(:proxy_user) { 'proxy_user1' }
+      let(:proxy_password) { 'proxy_password1' }
+      let(:proxy_options) {{
+        uri:      proxy_uri,
+        user:     proxy_user,
+        password: proxy_password,
+      }}
+
+      it 'configure proxy' do
+        stub = stub_request(:post, Sbpayment::SANDBOX_URL + Sbpayment::API_PATH).to_timeout
+        expect(Faraday::ProxyOptions).to receive('from').with(proxy_options).and_call_original
+        req = dummy_request
+        expect { req.perform }.to raise_error(Faraday::ConnectionFailed)
+        expect(stub).to have_been_requested.times(1)
+      end
+    end
+
+    context 'when proxy options not given' do
+      let(:proxy_uri) { nil }
+      let(:proxy_user) { nil }
+      let(:proxy_password) { nil }
+
+      it 'don\'t configure proxy' do
+        stub = stub_request(:post, Sbpayment::SANDBOX_URL + Sbpayment::API_PATH).to_timeout
+        expect(Faraday::ProxyOptions).not_to receive('from')
+        req = dummy_request
+        expect { req.perform }.to raise_error(Faraday::ConnectionFailed)
+        expect(stub).to have_been_requested.times(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In faraday 1.0+, we can't use `Faraday::Connection#proxy` to set proxy settings. Instead of it, we can use `Faraday::Connection#proxy=`. This method has been introduced since 0.13.0.
https://github.com/lostisland/faraday/commit/d18cc04be5c179b1b22b9dd1004030dd43b0ca58#diff-ec23de93634c9f1330648fecdfd152dfR288-R290

This PR fixes warnings like this with faraday < 1.0:

```
Warning: use of proxy(new_value) to set connection proxy have been DEPRECATED and will be removed in Faraday 1.0
```

In addition to that, this PR configures matrix tests against faraday and ruby.