### PR TITLE
Prefer Regexp#match? and drop ruby ~2.4 support

### DIFF
--- a/lib/sbpayment/api_error/fields.rb
+++ b/lib/sbpayment/api_error/fields.rb
@@ -11,7 +11,7 @@ module Sbpayment
 
         # @param code [String]
         def valid_code?(code)
-          !! self::PATTERN.match(code)
+          self::PATTERN.match?(code)
         end
 
         def check_code(code)
@@ -63,7 +63,7 @@ module Sbpayment
       define_children_from TYPE_COMMON_DEFINITIONS
 
       def retryable?
-        !!/\A[89]/.match(code) # Can not use `match?` until drop to less than ruby 2.4.0
+        /\A[89]/.match?(code)
       end
     end
 

--- a/lib/sbpayment/errors.rb
+++ b/lib/sbpayment/errors.rb
@@ -21,7 +21,7 @@ module Sbpayment
     # @return [String]
     def res_err_code
       str = "#{payment_method.code}#{type.code}#{@item.code}"
-      PATTERN.match(str) ? str : raise("should not reach here: #{str}")
+      PATTERN.match?(str) ? str : raise("should not reach here: #{str}")
     end
     alias_method :to_s, :res_err_code
 

--- a/sbpayment.gemspec
+++ b/sbpayment.gemspec
@@ -12,12 +12,12 @@ Gem::Specification.new do |spec|
   spec.description   = %q{A client library for sbpayment (SB Payment Service) written in Ruby.}
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| %r{^(test|spec|features)/}.match?(f) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'faraday', '>= 0.16.0', '< 1.4.0'
   spec.add_dependency 'builder'


### PR DESCRIPTION
https://github.com/quipper/sbpayment.rb/blob/71348e1628f50aeaf134dbc20a8c43d67d979f54/.circleci/config.yml#L31-L34

今のCIで check している version 的にも Official でのサポート状況的にも、とりあえず 2.4 以上対応ということにしてしまっていいのかなと思いました。

https://www.ruby-lang.org/ja/news/2020/04/05/support-of-ruby-2-4-has-ended/ (2.4も end ではある)