### PR TITLE
Raise specific error instead of ArgumentError for parsing failure

### DIFF
--- a/lib/sbpayment/errors.rb
+++ b/lib/sbpayment/errors.rb
@@ -5,6 +5,7 @@ require_relative 'api_error/feature_modules'
 module Sbpayment
   # Usualy, SBPS exceptions should be a subclass of this class or a nested subclass
   class Error < StandardError; end
+  class ParserError < Error; end
 
   # * We basically get special errors from `APIError.parse(error_code)`
   #   * When given an known `error_code`, this returns as a specific error, that is named as `API12345Error`
@@ -57,7 +58,7 @@ module Sbpayment
             end
           end
         else
-          raise ArgumentError, "given an invalid format: #{res_err_code}"
+          raise ParserError, "given an invalid format: #{res_err_code}"
         end
       end
     end

--- a/spec/sbpayment/errors_spec.rb
+++ b/spec/sbpayment/errors_spec.rb
@@ -1,8 +1,15 @@
 require_relative '../spec_helper'
 
 describe Sbpayment::Error do
-  subject { Sbpayment::Error.superclass }
+  subject { described_class.superclass }
+
   it { is_expected.to equal(StandardError) }
+end
+
+context Sbpayment::ParserError do
+  subject { described_class }
+
+  it { is_expected.to be < Sbpayment::Error }
 end
 
 describe Sbpayment::APIError do
@@ -19,11 +26,11 @@ describe Sbpayment::APIError do
       expect(Sbpayment::APIError.parse '11122333').to be_an_instance_of(Sbpayment::APIUnknownPaymentMethodError)
     end
 
-    it 'raises an ArgumentError when given an invalid format' do
-      expect { Sbpayment::APIError.parse '11122333\n' }.to raise_error(ArgumentError)
-      expect { Sbpayment::APIError.parse '1112!333' }.to raise_error(ArgumentError)
-      expect { Sbpayment::APIError.parse '111223339' }.to raise_error(ArgumentError)
-      expect { Sbpayment::APIError.parse '1112299' }.to raise_error(ArgumentError)
+    it 'raises a ParserError when given an invalid format' do
+      expect { Sbpayment::APIError.parse '11122333\n' }.to raise_error(Sbpayment::ParserError)
+      expect { Sbpayment::APIError.parse '1112!333' }.to raise_error(Sbpayment::ParserError)
+      expect { Sbpayment::APIError.parse '111223339' }.to raise_error(Sbpayment::ParserError)
+      expect { Sbpayment::APIError.parse '1112299' }.to raise_error(Sbpayment::ParserError)
     end
 
     context 'with common types' do


### PR DESCRIPTION
https://github.com/quipper/sbpayment.rb/pull/20 の中で、 大体の sbpayment.rb 由来の例外を `Sbpayment::Error` のサブクラスに変更しました。
その時、このパースエラーは特に触らなかったのですが、 `CSV::MalformedCSVError` や  `JSON::ParserError` の存在を考えると、ここはやはり Sbpayment::Error のサブクラスにしておいた方が良いかなと今更になって思いました。

https://docs.ruby-lang.org/ja/latest/class/CSV=3a=3aMalformedCSVError.html
https://docs.ruby-lang.org/ja/latest/class/JSON=3a=3aParserError.html

とはいえ互換性を壊す変更且つそれほど有意義な変更かと言われると自分にも自信が無いので、気になって一応PR出しておいたぐらいの温度感です。 機会があれば検討していただけると 🙏 

(例外名にもあまりこだわりはありません。 あえていうと `Malformed` 的な表現が意味的にぴったり来る気はするんですが、他で多そうなParserErrorという名前にしてしまいました。)