### PR TITLE
Improve dependency specifying

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in sbpayment.gemspec
 gemspec
 
-gem 'pry-byebug'
-gem 'webdrivers' unless ENV.key?('CIRCLECI')
+group :test do
+  gem 'webdrivers' unless ENV.key?('CIRCLECI')
+end

--- a/sbpayment.gemspec
+++ b/sbpayment.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 5.1.0'
   spec.add_development_dependency 'webmock', '~> 3.11.2'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'selenium-webdriver'
 end


### PR DESCRIPTION
正直 Gemfile と .gemspec の使い分けが未だにわかってないのですが、  test に grouping されないで pry-byebug と webdrivers が指定されているのはおかしいのでは？と思ったので変更してみました。

https://koic.hatenablog.com/entry/gemspec-vs-gemfile-for-development-dependency-gems を眺めたがやはりよくわからない・・・




