### PR TITLE
Remove unused code from spec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --colour
+--require spec_helper.rb

--- a/spec/requests/api/au_spec.rb
+++ b/spec/requests/api/au_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'au API behavior' do
   describe 'AuthorizationRequest' do
     around do |e|

--- a/spec/requests/api/callback_spec.rb
+++ b/spec/requests/api/callback_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Sbpayment::CallbackFactory do
   let(:request_header) { nil }
 

--- a/spec/requests/api/credit_spec.rb
+++ b/spec/requests/api/credit_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Credit API behavior' do
   describe 'without token' do
     before do

--- a/spec/requests/api/customer_spec.rb
+++ b/spec/requests/api/customer_spec.rb
@@ -138,7 +138,6 @@ describe 'Customer API behavior' do
       end
 
       it 'returns OK' do
-        token, tokenKey = get_tokens
         req = Sbpayment::API::Credit::UpdateCustomerTokenRequest.new
         req.cust_code = @cust_code_for_request_with_token
         req.encrypted_flg = '0'

--- a/spec/requests/api/customer_spec.rb
+++ b/spec/requests/api/customer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Customer API behavior' do
   let(:cust_code) { SecureRandom.hex }
 

--- a/spec/requests/api/docomo_spec.rb
+++ b/spec/requests/api/docomo_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-require 'securerandom'
-
 describe 'Docomo API behavior' do
   describe 'AuthorizationRequest' do
     around do |e|

--- a/spec/requests/api/payeasy_spec.rb
+++ b/spec/requests/api/payeasy_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'PayEasy API behavior' do
   before do
     Sbpayment.configure do |x|

--- a/spec/requests/api/proxy_spec.rb
+++ b/spec/requests/api/proxy_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'proxy behavior' do
 
   def dummy_request

--- a/spec/requests/api/softbank_spec.rb
+++ b/spec/requests/api/softbank_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Softbank API behavior' do
   pending 'Needs tracking_id from link type'
 end

--- a/spec/requests/api/timeout_spec.rb
+++ b/spec/requests/api/timeout_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'timeout behavior' do
 
   def dummy_request

--- a/spec/requests/api/webcvs_spec.rb
+++ b/spec/requests/api/webcvs_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Webcvs API behavior' do
   before do
     Sbpayment.configure do |x|

--- a/spec/sbpayment/configuration_spec.rb
+++ b/spec/sbpayment/configuration_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Sbpayment::Configuration do
   before do
     # reset Sbpayment::Config.instance for test because it's singleton

--- a/spec/sbpayment/crypto_spec.rb
+++ b/spec/sbpayment/crypto_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Sbpayment::Crypto do
   let(:key)  { SecureRandom.hex 12 }
   let(:iv)   { SecureRandom.hex  4 }

--- a/spec/sbpayment/decode_parameters_spec.rb
+++ b/spec/sbpayment/decode_parameters_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Sbpayment::DecodeParameters do
   class Example
     include Sbpayment::DecodeParameters

--- a/spec/sbpayment/errors_spec.rb
+++ b/spec/sbpayment/errors_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../spec_helper'
-
 describe Sbpayment::Error do
   subject { Sbpayment::Error.superclass }
   it { is_expected.to equal(StandardError) }

--- a/spec/sbpayment/link/purchase_report_spec.rb
+++ b/spec/sbpayment/link/purchase_report_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.shared_context "prepare purchase report params" do
   before do
     Sbpayment.configure do |x|

--- a/spec/sbpayment/link/purchase_request/validators_spec.rb
+++ b/spec/sbpayment/link/purchase_request/validators_spec.rb
@@ -1,7 +1,5 @@
 # coding: Shift_JIS
 
-require_relative '../../../spec_helper'
-
 describe Sbpayment::Link::PurchaseRequest::FREE_CSV_FIELD_VALIDATOR do
   subject { described_class }
 

--- a/spec/sbpayment/link/purchase_result_spec.rb
+++ b/spec/sbpayment/link/purchase_result_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.shared_context "prepare purchase result params" do
   before do
     Sbpayment.configure do |x|

--- a/spec/sbpayment/link/update_report_spec.rb
+++ b/spec/sbpayment/link/update_report_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Sbpayment::Link::UpdateReport do
   shared_context "prepare update result params" do
     before do

--- a/spec/sbpayment/link/update_result_spec.rb
+++ b/spec/sbpayment/link/update_result_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Sbpayment::Link::UpdateResult do
   shared_context "prepare update result params" do
     before do

--- a/spec/sbpayment/parameter_definition_spec.rb
+++ b/spec/sbpayment/parameter_definition_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'rexml/document'
 
 describe Sbpayment::ParameterDefinition do

--- a/spec/sbpayment/shallow_hash_spec.rb
+++ b/spec/sbpayment/shallow_hash_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Sbpayment::ShallowHash do
   using Sbpayment::ShallowHash
 

--- a/spec/sbpayment/time_util_spec.rb
+++ b/spec/sbpayment/time_util_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Sbpayment::TimeUtil do
   around do |example|
     ENV['TZ'], old = 'UTC', ENV['TZ']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ require 'selenium-webdriver'
 require_relative 'support/get_tokens_helper'
 
 RSpec.configure do |c|
+  c.warnings = true
+  c.raise_on_warning = true
   c.include GetTokensHelper
 end
 


### PR DESCRIPTION
* この行が使われていませんでした。
* 検知しやすくするように ruby の warning が `bundle exec rspec` 時に出るようにしました