### PR TITLE
Update CI rubies and test in latest too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ workflows:
                 - gemfiles/faraday-0.17/Gemfile
                 - gemfiles/faraday-1.0/Gemfile
               ruby-image:
-                - circleci/ruby:2.4.6-browsers
-                - circleci/ruby:2.5.5-browsers
-                - circleci/ruby:2.6.3-browsers
+                - circleci/ruby:2.4.9-browsers
+                - circleci/ruby:2.5.8-browsers
+                - circleci/ruby:2.6.6-browsers
+                - circleci/ruby:latest-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,5 @@ workflows:
                 - circleci/ruby:2.4.9-browsers
                 - circleci/ruby:2.5.8-browsers
                 - circleci/ruby:2.6.6-browsers
+                - circleci/ruby:2.7.2-browsers
                 - circleci/ruby:latest-browsers


### PR DESCRIPTION
latest 指定しておけば常に最新のrubyでtestしてくれるという認識なので合ってますかね？一応入れとくと安心かなと

ref: https://circleci.com/docs/ja/2.0/circleci-images/#ruby