### PR TITLE
Care bundler deprecation in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - checkout
       - run: gem update bundler
-      - run: bundle config set path vendor/bundle
+      - run: bundle config set --local path vendor/bundle
       - run: bundle check || bundle install --jobs=4 --retry=3
       - run: bundle exec rspec
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - checkout
       - run: gem update bundler
-      - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+      - run: bundle config set path vendor/bundle
+      - run: bundle check || bundle install --jobs=4 --retry=3
       - run: bundle exec rspec
 
 workflows:


### PR DESCRIPTION
https://circleci.com/docs/ja/2.0/sample-config/ には `--path` 指定の例が記載されているのですが、CIを見ているとこんなwarningが出ていました

```
#!/bin/bash -eo pipefail
bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle'`, and stop using this flag
Bundler can't satisfy your Gemfile's dependencies.
Install missing gems with `bundle install`.
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle'`, and stop using this flag
```

https://github.com/rubygems/bundler/blob/d4993be66fa2e76b3ca00ea56a51ecab5478b726/UPGRADING.md#cli-deprecations
https://bundler.io/man/bundle-config.1.html

そもそも https://github.com/circleci/circleci-docs/blob/475d95f06cb6bbf90544094835c6f53b2f5a24e9/jekyll/_cci2/language-ruby.md と https://github.com/circleci/circleci-docs/blob/475d95f06cb6bbf90544094835c6f53b2f5a24e9/jekyll/_cci2_ja/language-ruby.md の差が激しくて何が今ベストなconfigなのかよくわかっていないのですが、 `--path` 指定を除いてみたので確認していただけると 🙏 