### PR TITLE
Enable `Zero monkey patching mode` in rspec

### DIFF
--- a/spec/requests/api/au_spec.rb
+++ b/spec/requests/api/au_spec.rb
@@ -1,4 +1,4 @@
-describe 'au API behavior' do
+RSpec.describe 'au API behavior' do
   describe 'AuthorizationRequest' do
     around do |e|
       VCR.use_cassette 'au-authorization' do

--- a/spec/requests/api/callback_spec.rb
+++ b/spec/requests/api/callback_spec.rb
@@ -1,4 +1,4 @@
-describe Sbpayment::CallbackFactory do
+RSpec.describe Sbpayment::CallbackFactory do
   let(:request_header) { nil }
 
   describe 'PayEasy Notice' do

--- a/spec/requests/api/credit_spec.rb
+++ b/spec/requests/api/credit_spec.rb
@@ -1,4 +1,4 @@
-describe 'Credit API behavior' do
+RSpec.describe 'Credit API behavior' do
   describe 'without token' do
     before do
       Sbpayment.configure do |x|

--- a/spec/requests/api/customer_spec.rb
+++ b/spec/requests/api/customer_spec.rb
@@ -1,4 +1,4 @@
-describe 'Customer API behavior' do
+RSpec.describe 'Customer API behavior' do
   let(:cust_code) { SecureRandom.hex }
 
   describe 'withou token' do

--- a/spec/requests/api/docomo_spec.rb
+++ b/spec/requests/api/docomo_spec.rb
@@ -1,4 +1,4 @@
-describe 'Docomo API behavior' do
+RSpec.describe 'Docomo API behavior' do
   describe 'AuthorizationRequest' do
     around do |e|
       VCR.use_cassette 'docomo-authorization' do

--- a/spec/requests/api/payeasy_spec.rb
+++ b/spec/requests/api/payeasy_spec.rb
@@ -1,4 +1,4 @@
-describe 'PayEasy API behavior' do
+RSpec.describe 'PayEasy API behavior' do
   before do
     Sbpayment.configure do |x|
       x.sandbox = true

--- a/spec/requests/api/proxy_spec.rb
+++ b/spec/requests/api/proxy_spec.rb
@@ -1,4 +1,4 @@
-describe 'proxy behavior' do
+RSpec.describe 'proxy behavior' do
 
   def dummy_request
     req = Sbpayment::API::Credit::AuthorizationRequest.new

--- a/spec/requests/api/softbank_spec.rb
+++ b/spec/requests/api/softbank_spec.rb
@@ -1,3 +1,3 @@
-describe 'Softbank API behavior' do
+RSpec.describe 'Softbank API behavior' do
   pending 'Needs tracking_id from link type'
 end

--- a/spec/requests/api/timeout_spec.rb
+++ b/spec/requests/api/timeout_spec.rb
@@ -1,4 +1,4 @@
-describe 'timeout behavior' do
+RSpec.describe 'timeout behavior' do
 
   def dummy_request
     req = Sbpayment::API::Credit::AuthorizationRequest.new

--- a/spec/requests/api/webcvs_spec.rb
+++ b/spec/requests/api/webcvs_spec.rb
@@ -1,4 +1,4 @@
-describe 'Webcvs API behavior' do
+RSpec.describe 'Webcvs API behavior' do
   before do
     Sbpayment.configure do |x|
       x.sandbox = true

--- a/spec/sbpayment/configuration_spec.rb
+++ b/spec/sbpayment/configuration_spec.rb
@@ -1,4 +1,4 @@
-describe Sbpayment::Configuration do
+RSpec.describe Sbpayment::Configuration do
   before do
     # reset Sbpayment::Config.instance for test because it's singleton
     Sbpayment::Config.instance_variable_set('@singleton__instance__', nil)

--- a/spec/sbpayment/crypto_spec.rb
+++ b/spec/sbpayment/crypto_spec.rb
@@ -1,4 +1,4 @@
-describe Sbpayment::Crypto do
+RSpec.describe Sbpayment::Crypto do
   let(:key)  { SecureRandom.hex 12 }
   let(:iv)   { SecureRandom.hex  4 }
 

--- a/spec/sbpayment/decode_parameters_spec.rb
+++ b/spec/sbpayment/decode_parameters_spec.rb
@@ -1,4 +1,4 @@
-describe Sbpayment::DecodeParameters do
+RSpec.describe Sbpayment::DecodeParameters do
   class Example
     include Sbpayment::DecodeParameters
     DECRYPT_PARAMETERS = %i(foo bar)

--- a/spec/sbpayment/errors_spec.rb
+++ b/spec/sbpayment/errors_spec.rb
@@ -1,9 +1,9 @@
-describe Sbpayment::Error do
+RSpec.describe Sbpayment::Error do
   subject { Sbpayment::Error.superclass }
   it { is_expected.to equal(StandardError) }
 end
 
-describe Sbpayment::APIError do
+RSpec.describe Sbpayment::APIError do
   subject(:defined_api_error) { Sbpayment::APIError.parse '10123203' }
   subject(:undefined_api_error) { Sbpayment::APIError.parse '11122333' }
 
@@ -152,14 +152,14 @@ describe Sbpayment::APIError do
   end
 end
 
-describe 'Specific API error' do
+RSpec.describe 'Specific API error' do
   it 'has ancestors as APIKnownError > API000Error > API00099Error' do
     expect(Sbpayment::API101Error.superclass).to equal(Sbpayment::APIKnownError)
     expect(Sbpayment::API10123Error.superclass).to equal(Sbpayment::API101Error)
   end
 end
 
-describe Sbpayment::APIUnknownError do
+RSpec.describe Sbpayment::APIUnknownError do
   subject(:unknown_root) { Sbpayment::APIUnknownError }
 
   it 'is a subclass of Error' do
@@ -189,7 +189,7 @@ describe Sbpayment::APIUnknownError do
   end
 end
 
-describe Sbpayment::APIError::PaymentMethod do
+RSpec.describe Sbpayment::APIError::PaymentMethod do
   describe '.fetch' do
     subject { Sbpayment::APIError::PaymentMethod.fetch '405' }
     it { is_expected.to be_an_instance_of(Sbpayment::APIError::PaymentMethod) }
@@ -212,7 +212,7 @@ describe Sbpayment::APIError::PaymentMethod do
   end
 end
 
-describe Sbpayment::APIError::Type do
+RSpec.describe Sbpayment::APIError::Type do
   describe '.fetch' do
     subject { Sbpayment::APIError::Type.fetch '40' }
     it { is_expected.to be_an_instance_of(Sbpayment::APIError::Type) }

--- a/spec/sbpayment/link/purchase_report_spec.rb
+++ b/spec/sbpayment/link/purchase_report_spec.rb
@@ -15,7 +15,7 @@ RSpec.shared_context "prepare purchase report params" do
   end
 end
 
-describe Sbpayment::Link::PurchaseReport do
+RSpec.describe Sbpayment::Link::PurchaseReport do
   context 'when valid params are given' do
     include_context "prepare purchase report params" do
       let!(:query) { 'res_payinfo_key=&service_id=001&auto_charge_type=0&free1=&cust_code=498b1fd98ebeb074ff1d50f2e2720a1a&div_settele=0&free3=&res_sps_payment_no=&service_type=0&free2=&sps_hashcode=BE33A23EC4B61A34545E0A485D0897E33383F4DE&order_id=9eb2fced282c5bfc67c2417217ca2682&camp_type=&res_date=20150807161021&amount=980&res_err_code=&last_charge_month=&limit_second=600&pay_type=2&res_payment_date=20150807161021&merchant_id=19788&tracking_id=&res_tracking_id=80312789324671&request_date=20150807161004&pay_item_id=&res_pay_method=&terminal_type=0&res_sps_cust_no=&pay_method=&tax=&item_name=%8Cp%91%B1%89%DB%8B%E0&sps_payment_no=&res_result=OK&item_id=Item+ID&sps_cust_no=' }

--- a/spec/sbpayment/link/purchase_request/validators_spec.rb
+++ b/spec/sbpayment/link/purchase_request/validators_spec.rb
@@ -1,6 +1,6 @@
 # coding: Shift_JIS
 
-describe Sbpayment::Link::PurchaseRequest::FREE_CSV_FIELD_VALIDATOR do
+RSpec.describe Sbpayment::Link::PurchaseRequest::FREE_CSV_FIELD_VALIDATOR do
   subject { described_class }
 
   describe '.valid?' do
@@ -14,7 +14,7 @@ describe Sbpayment::Link::PurchaseRequest::FREE_CSV_FIELD_VALIDATOR do
   end
 end
 
-describe Sbpayment::Link::PurchaseRequest::FREE_CSV_EMAIL_VALIDATOR do
+RSpec.describe Sbpayment::Link::PurchaseRequest::FREE_CSV_EMAIL_VALIDATOR do
   subject { described_class }
 
   describe '.valid?' do

--- a/spec/sbpayment/link/purchase_result_spec.rb
+++ b/spec/sbpayment/link/purchase_result_spec.rb
@@ -15,7 +15,7 @@ RSpec.shared_context "prepare purchase result params" do
   end
 end
 
-describe Sbpayment::Link::PurchaseResult do
+RSpec.describe Sbpayment::Link::PurchaseResult do
   context 'when valid params are given' do
     include_context "prepare purchase result params" do
       let!(:query) { 'res_payinfo_key=&service_id=001&auto_charge_type=0&free1=&cust_code=498b1fd98ebeb074ff1d50f2e2720a1a&div_settele=0&free3=&res_sps_payment_no=&service_type=0&free2=&sps_hashcode=c27fa2286c6fcc2cef2ce31def31386c2e39783e&order_id=9eb2fced282c5bfc67c2417217ca2682&camp_type=&res_date=20150807161021&amount=980&res_err_code=&last_charge_month=&limit_second=600&pay_type=2&res_payment_date=20150807161021&merchant_id=19788&tracking_id=&res_tracking_id=80312789324671&request_date=20150807161004&pay_item_id=&res_pay_method=&terminal_type=0&res_sps_cust_no=&pay_method=&tax=&item_name=%8Cp%91%B1%89%DB%8B%E0&sps_payment_no=&res_result=OK&item_id=Item+ID&sps_cust_no=' }

--- a/spec/sbpayment/link/update_report_spec.rb
+++ b/spec/sbpayment/link/update_report_spec.rb
@@ -1,4 +1,4 @@
-describe Sbpayment::Link::UpdateReport do
+RSpec.describe Sbpayment::Link::UpdateReport do
   shared_context "prepare update result params" do
     before do
       Sbpayment.configure do |x|

--- a/spec/sbpayment/link/update_result_spec.rb
+++ b/spec/sbpayment/link/update_result_spec.rb
@@ -1,4 +1,4 @@
-describe Sbpayment::Link::UpdateResult do
+RSpec.describe Sbpayment::Link::UpdateResult do
   shared_context "prepare update result params" do
     before do
       Sbpayment.configure do |x|

--- a/spec/sbpayment/parameter_definition_spec.rb
+++ b/spec/sbpayment/parameter_definition_spec.rb
@@ -1,6 +1,6 @@
 require 'rexml/document'
 
-describe Sbpayment::ParameterDefinition do
+RSpec.describe Sbpayment::ParameterDefinition do
   class Example
     include Sbpayment::ParameterDefinition
 

--- a/spec/sbpayment/shallow_hash_spec.rb
+++ b/spec/sbpayment/shallow_hash_spec.rb
@@ -1,4 +1,4 @@
-describe Sbpayment::ShallowHash do
+RSpec.describe Sbpayment::ShallowHash do
   using Sbpayment::ShallowHash
 
   describe 'Hash#shallow' do

--- a/spec/sbpayment/time_util_spec.rb
+++ b/spec/sbpayment/time_util_spec.rb
@@ -1,4 +1,4 @@
-describe Sbpayment::TimeUtil do
+RSpec.describe Sbpayment::TimeUtil do
   around do |example|
     ENV['TZ'], old = 'UTC', ENV['TZ']
     example.run

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'selenium-webdriver'
 require_relative 'support/get_tokens_helper'
 
 RSpec.configure do |c|
+  c.disable_monkey_patching!
   c.warnings = true
   c.raise_on_warning = true
   c.include GetTokensHelper


### PR DESCRIPTION
https://relishapp.com/rspec/rspec-core/v/3-9/docs/configuration/zero-monkey-patching-mode これを enable にするPRです。
初期の頃は should から変わるの嫌だ的意見も多かったと思うのですが最近殆ど聞かないのと、既存の spec が全部 should 使ってなかったようなのでいっそ縛っておいたほうが良いかなと。

https://relishapp.com/rspec/rspec-core/v/3-9/docs/configuration/global-namespace-dsl の disable と両方onにした方が良いのか？ と最初は思ったんですが 

https://github.com/rspec/rspec-core/blob/ecb65d2d4ea7b381472e3084f45e2da94e00ce91/lib/rspec/core/configuration.rb#L1844-L1846

これ見る限り、  `Zero monkey patching mode` が  `Global namespace DSL の disable` も内包しているようです。