### PR TITLE
drop ruby 2.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ workflows:
                 - gemfiles/faraday-1.0/Gemfile
                 - gemfiles/faraday-1.4/Gemfile
               ruby-image:
-                - circleci/ruby:2.5.9-browsers
                 - circleci/ruby:2.6.7-browsers
                 - circleci/ruby:2.7.3-browsers
                 - circleci/ruby:latest-browsers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Breaking Changes
-- Drop support for Ruby 2.4
+- Drop support for Ruby 2.4 and 2.5
 
 ## v0.15.0
 

--- a/sbpayment.gemspec
+++ b/sbpayment.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'faraday', '>= 0.16.0', '< 1.5.0'
   spec.add_dependency 'builder'


### PR DESCRIPTION
EOL ruby 2.5
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/